### PR TITLE
Verbosity

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,3 +14,17 @@ coverage:
         only_pulls: false
         flags: null
         paths: null
+    patch:
+      default:
+        # basic
+        target: auto
+        threshold: 0.2
+        base: auto 
+        # advanced
+        branches: null
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: error
+        only_pulls: false
+        flags: null
+        paths: null

--- a/.coveragerc
+++ b/.coveragerc
@@ -16,3 +16,4 @@ exclude_lines =
     if 0:
     if __name__ == .__main__.:
     __version__
+    if verbose

--- a/pymfe/_internal.py
+++ b/pymfe/_internal.py
@@ -251,11 +251,12 @@ def _check_values_in_group(value: t.Union[str, t.Iterable[str]],
     return tuple(in_group), tuple(not_in_group)
 
 
-def get_prefixed_mtds_from_class(class_obj: t.Any,
-                                 prefix: str,
-                                 only_name: bool = False,
-                                 prefix_removal: bool = False,
-                                 ) -> t.List[t.Union[str, TypeMtdTuple]]:
+def get_prefixed_mtds_from_class(
+        class_obj: t.Any,
+        prefix: str,
+        only_name: bool = False,
+        prefix_removal: bool = False,
+        ) -> t.Union[t.List[str], t.List[TypeMtdTuple]]:
     """Get all class methods from ``class_obj`` prefixed with ``prefix``.
 
     Args:
@@ -284,7 +285,8 @@ def get_prefixed_mtds_from_class(class_obj: t.Any,
     # It is assumed that all feature-extraction related methods
     # name are all prefixed with "MTF_PREFIX" and all precomputa-
     # tion methos, prefixed with "PRECOMPUTE_PREFIX".
-    feat_mtd_list = []  # type: t.List[t.Union[str, TypeMtdTuple]]
+
+    feat_mtd_list = []  # type: t.List
 
     for ft_method in class_methods:
         mtd_name, remaining_data = ft_method[0], ft_method[1:]
@@ -1475,15 +1477,17 @@ def select_results_by_classes(
     if include_dependencies:
         class_names.update(check_group_dependencies(groups=class_names))
 
-    classes_mtd_names = set()
+    classes_mtd_names = set()  # type: t.Set[str]
 
     for class_name in class_names:
         if class_name in VALID_GROUPS:
-            classes_mtd_names.update(get_prefixed_mtds_from_class(
+            _aux = get_prefixed_mtds_from_class(
                 class_obj=VALID_MFECLASSES[VALID_GROUPS.index(class_name)],
                 prefix=MTF_PREFIX,
                 only_name=True,
-                prefix_removal=True))
+                prefix_removal=True)
+
+            classes_mtd_names.update(_aux)  # type: ignore
 
     re_parse_mtf_name = re.compile(r"([^\.]+)\.?")
 

--- a/pymfe/clustering.py
+++ b/pymfe/clustering.py
@@ -443,9 +443,9 @@ class MFEClustering:
                             "or a sequence or a numpy array. "
                             "Got '{}'.".format(type(representative)))
 
-        representative = np.array(representative)
+        representative_arr = np.asarray(representative)
 
-        num_repr, repr_dim = representative.shape
+        num_repr, repr_dim = representative_arr.shape
         _, num_attr = N.shape
 
         if num_repr != classes.size:
@@ -456,9 +456,9 @@ class MFEClustering:
         if repr_dim != num_attr:
             raise ValueError("The dimension of each class representative "
                              "must match the instances dimension. (Expected "
-                             "'{}', got '{}'".format(classes.size, num_repr))
+                             "'{}', got '{}'".format(classes.size, repr_dim))
 
-        return representative
+        return representative_arr
 
     @classmethod
     def ft_vdu(

--- a/pymfe/clustering.py
+++ b/pymfe/clustering.py
@@ -698,10 +698,10 @@ class MFEClustering:
 
         Notes
         -----
-            .. _cahascore: ``sklearn.metrics.calinski_harabasz_score``
+            .. _cahascore: ``sklearn.metrics.calinski_harabaz_score``
                 documentation.
         """
-        return sklearn.metrics.calinski_harabasz_score(X=N, labels=y)
+        return sklearn.metrics.calinski_harabaz_score(X=N, labels=y)
 
     @classmethod
     def ft_nre(

--- a/pymfe/clustering.py
+++ b/pymfe/clustering.py
@@ -688,20 +688,20 @@ class MFEClustering:
             cls,
             N: np.ndarray,
             y: np.ndarray) -> float:
-        """Calinski and Harabaz index.
+        """Calinski and Harabasz index.
         Check `cahascore`_ for more information.
 
         Returns
         -------
         :obj:`float`
-            Calinski-Harabanz index.
+            Calinski-Harabasz index.
 
         Notes
         -----
-            .. _cahascore: ``sklearn.metrics.calinski_harabaz_score``
+            .. _cahascore: ``sklearn.metrics.calinski_harabasz_score``
                 documentation.
         """
-        return sklearn.metrics.calinski_harabaz_score(X=N, labels=y)
+        return sklearn.metrics.calinski_harabasz_score(X=N, labels=y)
 
     @classmethod
     def ft_nre(

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -457,7 +457,7 @@ class MFE:
         for ft_mtd_name, ft_mtd_callable, ft_mtd_args in self._metadata_mtd_ft:
 
             if verbose >= 2:
-                print("Extracting {} feature...".format(ft_mtd_name))
+                print("\nExtracting {} feature...".format(ft_mtd_name))
 
             ft_name_without_prefix = _internal.remove_prefix(
                 value=ft_mtd_name, prefix=_internal.MTF_PREFIX)
@@ -1053,7 +1053,7 @@ class MFE:
                 time_type = "total"
 
             print(
-                "Metafeature extraction process done.",
+                "\nMetafeature extraction process done.",
                 "Total of {0} values obtained. Time elapsed "
                 "({1}) = {2:.8f} seconds.".format(
                     len(res_vals), time_type, np.sum(res_times)),

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -420,6 +420,10 @@ class MFE:
 
         _t_num_cols, _ = shutil.get_terminal_size()
         _t_num_cols -= 8
+
+        if _t_num_cols <= 0:
+            return
+
         _total_prog_symb = int(cur_progress * _t_num_cols / 100)
 
         print("".join([

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -434,7 +434,9 @@ class MFE:
             verbose: int = 0,
             # enable_parallel: bool = False,
             suppress_warnings: bool = False,
-            **kwargs) -> t.Tuple[t.List, ...]:
+            **kwargs) -> t.Tuple[t.List[str],
+                                 t.List[t.Union[int, float, t.Sequence]],
+                                 t.List[float]]:
         """Invoke feature methods/functions loaded in the model and gather
         results.
 
@@ -1023,7 +1025,7 @@ class MFE:
             verbose=verbose,
             enable_parallel=enable_parallel,
             suppress_warnings=suppress_warnings,
-            **kwargs)
+            **kwargs)  # type: t.Tuple[t.List, ...]
 
         _internal.post_processing(
             results=results,
@@ -1050,7 +1052,7 @@ class MFE:
                 "Metafeature extraction process done.",
                 "Total of {0} values obtained. Time elapsed "
                 "({1}) = {2:.8f} seconds.".format(
-                    len(res_vals), time_type, sum(res_times)),
+                    len(res_vals), time_type, np.sum(res_times)),
                 sep="\n")
 
         if self.timeopt:
@@ -1136,11 +1138,11 @@ class MFE:
 
         deps = _internal.check_group_dependencies(groups)
 
-        mtf_names = []  # type: t.List[str]
+        mtf_names = []  # type: t.List
         for group in groups.union(deps):
             class_ind = _internal.VALID_GROUPS.index(group)
 
-            mtf_names += (  # type: ignore
+            mtf_names += (
                 _internal.get_prefixed_mtds_from_class(
                     class_obj=_internal.VALID_MFECLASSES[class_ind],
                     prefix=_internal.MTF_PREFIX,

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -410,12 +410,12 @@ class MFE:
     def _print_verbose_progress(
             cls,
             cur_progress: float,
-            cur_metaft: str,
+            cur_mtf_name: str,
             verbose: int = 0) -> None:
         """Print messages about extraction progress based on ``verbose``."""
         if verbose >= 2:
             print("Done with {} feature (progress of {:.2f}%)."
-                  .format(cur_metaft, cur_progress))
+                  .format(cur_mtf_name, cur_progress))
             return
 
         _t_num_cols, _ = shutil.get_terminal_size()
@@ -505,7 +505,7 @@ class MFE:
 
                 self._print_verbose_progress(
                     cur_progress=100 * ind / len(self._metadata_mtd_ft),
-                    cur_metaft=ft_mtd_name,
+                    cur_mtf_name=ft_mtd_name,
                     verbose=verbose)
 
         if verbose == 1:

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -419,7 +419,7 @@ class MFE:
             return
 
         _t_num_cols, _ = shutil.get_terminal_size()
-        _t_num_cols -= 8
+        _t_num_cols -= 9
 
         if _t_num_cols <= 0:
             return

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -500,12 +500,13 @@ class MFE:
                 metafeat_names.append(ft_name_without_prefix)
                 metafeat_times.append(time_ft)
 
-            ind += 1
+            if verbose > 0:
+                ind += 1
 
-            self._print_verbose_progress(
-                cur_progress=100 * ind / len(self._metadata_mtd_ft),
-                cur_metaft=ft_mtd_name,
-                verbose=verbose)
+                self._print_verbose_progress(
+                    cur_progress=100 * ind / len(self._metadata_mtd_ft),
+                    cur_metaft=ft_mtd_name,
+                    verbose=verbose)
 
         if verbose == 1:
             _t_num_cols, _ = shutil.get_terminal_size()

--- a/tests/test_errors_warnings.py
+++ b/tests/test_errors_warnings.py
@@ -259,26 +259,10 @@ class TestErrorsWarnings:
             model = MFE(features="sd").fit(X=X.values, y=y.values)
             model.extract(sd={"ddof": 1, "invalid": "value?"})
 
-    def test_verbose(self, capsys):
-        X, y = load_xy(0)
-        model = MFE(features=["freq_class",
-                              "mean",
-                              "class_conc",
-                              "one_nn",
-                              "nodes"]).fit(X=X.values, y=y.values)
-        model.extract(verbose=True)
-        captured = capsys.readouterr().out
-
-        # Expected number of messages in verbose mode of mtf extraction
-        expected_msg_num = 21
-
-        assert captured.count("\n") == expected_msg_num
-
     def test_error_rescale_data(self):
         X, y = load_xy(0)
         with pytest.raises(ValueError):
             _internal.rescale_data(X, option="42")
-
 
     def test_error_transform_num(self):
         X, y = load_xy(0)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -64,3 +64,30 @@ class TestErrorsWarnings:
             vals, names, time = res
 
             assert len(vals) == len(names) == len(time)
+
+        @pytest.mark.parametrize(
+            "verbosity, msg_expected",
+            [
+                (0, False),
+                (1, True),
+                (2, True),
+            ])
+        def test_verbosity_1(self, verbosity, msg_expected, capsys):
+            MFE._print_verbose_progress(
+                cur_progress=0,
+                cur_mtf_name="foo",
+                verbose=verbosity)
+
+            captured = capsys.readouterr().out
+
+            assert (not msg_expected) or captured
+
+        def test_verbosity_2(self, capsys):
+            X, y = load_xy(0)
+
+            MFE().fit(X=X.values,
+                      y=y.values).extract(verbose=0)
+
+            captured = capsys.readouterr().out
+
+            assert not captured

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -91,3 +91,20 @@ class TestErrorsWarnings:
             captured = capsys.readouterr().out
 
             assert not captured
+
+        @pytest.mark.parametrize(
+            "verbosity, msg_expected",
+            [
+                (0, False),
+                (1, True),
+                (2, True),
+            ])
+        def test_verbosity_3(self, verbosity, msg_expected, capsys):
+            X, y = load_xy(0)
+
+            MFE().fit(X=X.values,
+                      y=y.values).extract(verbose=verbosity)
+
+            captured = capsys.readouterr().out
+
+            assert (not msg_expected) or captured

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,8 +1,16 @@
 """Test module for General class metafeatures."""
 import pytest
 
+import pymfe._internal
 import pymfe._summary
+import pymfe.mfe
 import numpy as np
+
+
+def test_get_summary():
+    assert (not set(pymfe.mfe.MFE.valid_summary())
+                .symmetric_difference(pymfe._internal.VALID_SUMMARY))
+
 
 def test_sum_histogram():
     mf = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]


### PR DESCRIPTION
Updates due to #41.

- Modified 'verbosity' (from 'extract' method) argument type from boolean to integer. Now the user can choose the desired level of verbosity. Verbosity = 1 means that a progress bar will be shown during the metafeature extraction process. Verbosity = 2 maintains all the previous verbose messages (i.e., it logs every "extract" step) plus additional information about the current percentage of progress done so far.
- Removed tests related the number of messages printed in "verbose" mode.