### PR TITLE
Landmarking updates

### DIFF
--- a/pymfe/landmarking.py
+++ b/pymfe/landmarking.py
@@ -237,8 +237,8 @@ class MFELandmarking:
             split data in train/test sets.
 
         num_cv_folds : :obj: `int`, optional
-            Number of num_cv_folds to k-fold cross validation. Used only if ``skf``
-            is None.
+            Number of num_cv_folds to k-fold cross validation. Used only if
+            ``skf`` is None.
 
         shuffle_cv_folds : :obj:`bool`, optional
             If True, shuffle the data before splitting into the k-fold cross
@@ -322,8 +322,8 @@ class MFELandmarking:
             split data in train/test sets.
 
         num_cv_folds : :obj: `int`, optional
-            Number of num_cv_folds to k-fold cross validation. Used only if ``skf``
-            is None.
+            Number of num_cv_folds to k-fold cross validation. Used only if
+            ``skf`` is None.
 
         shuffle_cv_folds : :obj:`bool`, optional
             If True, shuffle the data before splitting into the k-fold cross
@@ -415,8 +415,8 @@ class MFELandmarking:
             split data in train/test sets.
 
         num_cv_folds : :obj: `int`, optional
-            Number of num_cv_folds to k-fold cross validation. Used only if ``skf``
-            is None.
+            Number of num_cv_folds to k-fold cross validation. Used only if
+            ``skf`` is None.
 
         shuffle_cv_folds : :obj:`bool`, optional
             If True, shuffle the data before splitting into the k-fold cross
@@ -508,8 +508,8 @@ class MFELandmarking:
             split data in train/test sets.
 
         num_cv_folds : :obj: `int`, optional
-            Number of num_cv_folds to k-fold cross validation. Used only if ``skf``
-            is None.
+            Number of num_cv_folds to k-fold cross validation. Used only if
+            ``skf`` is None.
 
         shuffle_cv_folds : :obj:`bool`, optional
             If True, shuffle the data before splitting into the k-fold cross
@@ -597,8 +597,8 @@ class MFELandmarking:
             split data in train/test sets.
 
         num_cv_folds : :obj: `int`, optional
-            Number of num_cv_folds to k-fold cross validation. Used only if ``skf``
-            is None.
+            Number of num_cv_folds to k-fold cross validation. Used only if
+            ``skf`` is None.
 
         shuffle_cv_folds : :obj:`bool`, optional
             If True, shuffle the data before splitting into the k-fold cross
@@ -686,8 +686,8 @@ class MFELandmarking:
             split data in train/test sets.
 
         num_cv_folds : :obj: `int`, optional
-            Number of num_cv_folds to k-fold cross validation. Used only if ``skf``
-            is None.
+            Number of num_cv_folds to k-fold cross validation. Used only if
+            ``skf`` is None.
 
         shuffle_cv_folds : :obj:`bool`, optional
             If True, shuffle the data before splitting into the k-fold cross
@@ -781,8 +781,8 @@ class MFELandmarking:
             split data in train/test sets.
 
         num_cv_folds : :obj: `int`, optional
-            Number of num_cv_folds to k-fold cross validation. Used only if ``skf``
-            is None.
+            Number of num_cv_folds to k-fold cross validation. Used only if
+            ``skf`` is None.
 
         shuffle_cv_folds : :obj:`bool`, optional
             If True, shuffle the data before splitting into the k-fold cross

--- a/pymfe/landmarking.py
+++ b/pymfe/landmarking.py
@@ -121,7 +121,7 @@ class MFELandmarking:
     @classmethod
     def _get_sample_inds(cls, num_inst: int, sample_size: float,
                          random_state: t.Optional[int]) -> np.ndarray:
-        """Sample inds to calculate subsampling landmarking metafeatures."""
+        """Sample indices to calculate subsampling landmarking metafeatures."""
         if random_state is not None:
             np.random.seed(random_state)
 
@@ -162,7 +162,7 @@ class MFELandmarking:
             sample_inds: t.Optional[np.ndarray] = None,
             random_state: t.Optional[int] = None,
     ) -> np.ndarray:
-        """Compute the Gini inds of a decision tree.
+        """Compute the Gini index of a decision tree.
 
         It is used the ``DecisionTreeClassifier`` implementation
         from ``sklearn`` package.
@@ -180,7 +180,7 @@ class MFELandmarking:
             metafeature. Used only if ``sample_inds`` is None.
 
         sample_inds : :obj:`np.ndarray`, optional
-            Array of inds of instances to be effectively used while
+            Array of indices of instances to be effectively used while
             extracting this metafeature. If None, then ``sample_size``
             is taken into account. Argument used to exploit precomputations.
 
@@ -250,7 +250,7 @@ class MFELandmarking:
             metafeature. Used only if ``sample_inds`` is None.
 
         sample_inds : :obj:`np.ndarray`, optional
-            Array of inds of instances to be effectively used while
+            Array of indices of instances to be effectively used while
             extracting this metafeature. If None, then ``sample_size``
             is taken into account. Argument used to exploit precomputations.
 
@@ -335,7 +335,7 @@ class MFELandmarking:
             metafeature. Used only if ``sample_inds`` is None.
 
         sample_inds : :obj:`np.ndarray`, optional
-            Array of inds of instances to be effectively used while
+            Array of indices of instances to be effectively used while
             extracting this metafeature. If None, then ``sample_size``
             is taken into account. Argument used to exploit precomputations.
 
@@ -428,7 +428,7 @@ class MFELandmarking:
             metafeature. Used only if ``sample_inds`` is None.
 
         sample_inds : :obj:`np.ndarray`, optional
-            Array of inds of instances to be effectively used while
+            Array of indices of instances to be effectively used while
             extracting this metafeature. If None, then ``sample_size``
             is taken into account. Argument used to exploit precomputations.
 
@@ -521,7 +521,7 @@ class MFELandmarking:
             metafeature. Used only if ``sample_inds`` is None.
 
         sample_inds : :obj:`np.ndarray`, optional
-            Array of inds of instances to be effectively used while
+            Array of indices of instances to be effectively used while
             extracting this metafeature. If None, then ``sample_size``
             is taken into account. Argument used to exploit precomputations.
 
@@ -610,7 +610,7 @@ class MFELandmarking:
             metafeature. Used only if ``sample_inds`` is None.
 
         sample_inds : :obj:`np.ndarray`, optional
-            Array of inds of instances to be effectively used while
+            Array of indices of instances to be effectively used while
             extracting this metafeature. If None, then ``sample_size``
             is taken into account. Argument used to exploit precomputations.
 
@@ -699,7 +699,7 @@ class MFELandmarking:
             metafeature. Used only if ``sample_inds`` is None.
 
         sample_inds : :obj:`np.ndarray`, optional
-            Array of inds of instances to be effectively used while
+            Array of indices of instances to be effectively used while
             extracting this metafeature. If None, then ``sample_size``
             is taken into account. Argument used to exploit precomputations.
 
@@ -794,7 +794,7 @@ class MFELandmarking:
             metafeature. Used only if ``sample_inds`` is None.
 
         sample_inds : :obj:`np.ndarray`, optional
-            Array of inds of instances to be effectively used while
+            Array of indices of instances to be effectively used while
             extracting this metafeature. If None, then ``sample_size``
             is taken into account. Argument used to exploit precomputations.
 

--- a/pymfe/landmarking.py
+++ b/pymfe/landmarking.py
@@ -114,7 +114,7 @@ class MFELandmarking:
             prepcomp_vals["skf"] = StratifiedKFold(
                 n_splits=num_cv_folds,
                 shuffle=shuffle_cv_folds,
-                random_state=random_state)
+                random_state=random_state if shuffle_cv_folds else None)
 
         return prepcomp_vals
 
@@ -275,7 +275,7 @@ class MFELandmarking:
             skf = StratifiedKFold(
                 n_splits=num_cv_folds,
                 shuffle=shuffle_cv_folds,
-                random_state=random_state)
+                random_state=random_state if shuffle_cv_folds else None)
 
         result = np.zeros(skf.n_splits, dtype=float)
         for fold_ind, split_inds in enumerate(skf.split(N, y)):
@@ -360,7 +360,7 @@ class MFELandmarking:
             skf = StratifiedKFold(
                 n_splits=num_cv_folds,
                 shuffle=shuffle_cv_folds,
-                random_state=random_state)
+                random_state=random_state if shuffle_cv_folds else None)
 
         if random_state is not None:
             np.random.seed(random_state)
@@ -453,7 +453,7 @@ class MFELandmarking:
             skf = StratifiedKFold(
                 n_splits=num_cv_folds,
                 shuffle=shuffle_cv_folds,
-                random_state=random_state)
+                random_state=random_state if shuffle_cv_folds else None)
 
         result = np.zeros(skf.n_splits, dtype=float)
         for fold_ind, split_inds in enumerate(skf.split(N, y)):
@@ -546,7 +546,7 @@ class MFELandmarking:
             skf = StratifiedKFold(
                 n_splits=num_cv_folds,
                 shuffle=shuffle_cv_folds,
-                random_state=random_state)
+                random_state=random_state if shuffle_cv_folds else None)
 
         result = np.zeros(skf.n_splits, dtype=float)
         for fold_ind, split_inds in enumerate(skf.split(N, y)):
@@ -635,7 +635,7 @@ class MFELandmarking:
             skf = StratifiedKFold(
                 n_splits=num_cv_folds,
                 shuffle=shuffle_cv_folds,
-                random_state=random_state)
+                random_state=random_state if shuffle_cv_folds else None)
 
         result = np.zeros(skf.n_splits, dtype=float)
         for fold_ind, split_inds in enumerate(skf.split(N, y)):
@@ -724,7 +724,7 @@ class MFELandmarking:
             skf = StratifiedKFold(
                 n_splits=num_cv_folds,
                 shuffle=shuffle_cv_folds,
-                random_state=random_state)
+                random_state=random_state if shuffle_cv_folds else None)
 
         result = np.zeros(skf.n_splits, dtype=float)
         for fold_ind, split_inds in enumerate(skf.split(N, y)):
@@ -819,7 +819,7 @@ class MFELandmarking:
             skf = StratifiedKFold(
                 n_splits=num_cv_folds,
                 shuffle=shuffle_cv_folds,
-                random_state=random_state)
+                random_state=random_state if shuffle_cv_folds else None)
 
         result = np.zeros(skf.n_splits, dtype=float)
         for fold_ind, split_inds in enumerate(skf.split(N, y)):

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -45,9 +45,10 @@ class MFE:
                  summary: t.Union[str, t.Iterable[str]] = ("mean", "sd"),
                  measure_time: t.Optional[str] = None,
                  wildcard: str = "all",
-                 score="accuracy",
-                 folds=10,
-                 sample_size=1.0,
+                 score: str = "accuracy",
+                 num_cv_folds: int = 10,
+                 shuffle_cv_folds: bool = False,
+                 sample_size: float = 1.0,
                  suppress_warnings: bool = False,
                  random_state: t.Optional[int] = None) -> None:
         """This class provides easy access for metafeature extraction from
@@ -157,20 +158,29 @@ class MFE:
             Value used as ``select all`` for ``groups``, ``features`` and
             ``summary`` arguments.
 
-         score : :obj:`str`, optional
+        score : :obj:`str`, optional
             Score metric used to extract ``landmarking`` metafeatures.
 
-         folds : :obj:`int`, optional
-            Number of folds to create a Stratified K-Fold cross validation
+        num_cv_folds : :obj:`int`, optional
+            Number of num_cv_folds to create a Stratified K-Fold cross validation
             to produce the ``landmarking`` metafeatures.
 
-         sample_size : :obj:`float`, optional
+        shuffle_cv_folds : :obj:`bool`, optional
+            If True, then the fitted data will be shuffled before splitted in
+            the Stratified K-Fold Cross Validation of ``landmarking`` features.
+            The shuffle random seed is the ``random_state`` argument.
+
+        sample_size : :obj:`float`, optional
             Sample proportion used to produce the ``landmarking`` metafeatures.
             This argument must be in 0.5 and 1.0 (both inclusive) interval.
 
         suppress_warnings : :obj:`bool`, optional
             If True, then ignore all warnings invoked at the instantiation
             time.
+
+        random_state : :obj:`int`, optional
+            Random seed used to control random events. Keeps the experiments
+            reproducible.
 
         Notes
         -----
@@ -262,10 +272,13 @@ class MFE:
                 'Invalid "random_state" argument ({0}). '
                 'Expecting None or an integer.'.format(random_state))
 
-        if isinstance(folds, int):
-            self.folds = folds
+        self.shuffle_cv_folds = shuffle_cv_folds
+
+        if isinstance(num_cv_folds, int):
+            self.num_cv_folds = num_cv_folds
+
         else:
-            raise ValueError('Invalid "folds" argument ({0}). '
+            raise ValueError('Invalid "num_cv_folds" argument ({0}). '
                              'Expecting an integer.'.format(random_state))
 
         if isinstance(sample_size, int):
@@ -888,7 +901,8 @@ class MFE:
             "N": data_num,
             "C": data_cat,
             "y": self.y,
-            "folds": self.folds,
+            "num_cv_folds": self.num_cv_folds,
+            "shuffle_cv_folds": self.shuffle_cv_folds,
             "sample_size": self.sample_size,
             "score": self.score,
             "random_state": self.random_state,

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -48,11 +48,10 @@ class MFE:
                  score: str = "accuracy",
                  num_cv_folds: int = 10,
                  shuffle_cv_folds: bool = False,
-                 sample_size: float = 1.0,
+                 lm_sample_frac: float = 1.0,
                  suppress_warnings: bool = False,
                  random_state: t.Optional[int] = None) -> None:
-        """This class provides easy access for metafeature extraction from
-        datasets.
+        """Provides easy access for metafeature extraction from datasets.
 
         It expected that user first calls ``fit`` method after instantiation
         and then ``extract`` for effectively extract the selected metafeatures.
@@ -170,7 +169,7 @@ class MFE:
             the Stratified K-Fold Cross Validation of ``landmarking`` features.
             The shuffle random seed is the ``random_state`` argument.
 
-        sample_size : :obj:`float`, optional
+        lm_sample_frac : :obj:`float`, optional
             Sample proportion used to produce the ``landmarking`` metafeatures.
             This argument must be in 0.5 and 1.0 (both inclusive) interval.
 
@@ -281,15 +280,15 @@ class MFE:
             raise ValueError('Invalid "num_cv_folds" argument ({0}). '
                              'Expecting an integer.'.format(random_state))
 
-        if isinstance(sample_size, int):
-            sample_size = float(sample_size)
+        if isinstance(lm_sample_frac, int):
+            lm_sample_frac = float(lm_sample_frac)
 
-        if isinstance(sample_size, float)\
-           and 0.5 <= sample_size <= 1.0:
-            self.sample_size = sample_size
+        if isinstance(lm_sample_frac, float)\
+           and 0.5 <= lm_sample_frac <= 1.0:
+            self.lm_sample_frac = lm_sample_frac
 
         else:
-            raise ValueError('Invalid "sample_size" argument ({0}). '
+            raise ValueError('Invalid "lm_sample_frac" argument ({0}). '
                              'Expecting an float [0.5, 1].'
                              .format(random_state))
 
@@ -903,7 +902,7 @@ class MFE:
             "y": self.y,
             "num_cv_folds": self.num_cv_folds,
             "shuffle_cv_folds": self.shuffle_cv_folds,
-            "sample_size": self.sample_size,
+            "lm_sample_frac": self.lm_sample_frac,
             "score": self.score,
             "random_state": self.random_state,
             "cat_cols": self._attr_indexes_cat,

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -162,8 +162,8 @@ class MFE:
             Score metric used to extract ``landmarking`` metafeatures.
 
         num_cv_folds : :obj:`int`, optional
-            Number of num_cv_folds to create a Stratified K-Fold cross validation
-            to produce the ``landmarking`` metafeatures.
+            Number of num_cv_folds to create a Stratified K-Fold cross
+            validation to extract the ``landmarking`` metafeatures.
 
         shuffle_cv_folds : :obj:`bool`, optional
             If True, then the fitted data will be shuffled before splitted in

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -162,7 +162,7 @@ class MFE:
             Score metric used to extract ``landmarking`` metafeatures.
 
         num_cv_folds : :obj:`int`, optional
-            Number of num_cv_folds to create a Stratified K-Fold cross
+            Number of folds to create a Stratified K-Fold cross
             validation to extract the ``landmarking`` metafeatures.
 
         shuffle_cv_folds : :obj:`bool`, optional

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -220,7 +220,7 @@ class TestArchitecture:
         mfe = MFE(
             groups="all",
             summary=None,
-            sample_size=0.5,
+            lm_sample_frac=0.5,
             random_state=1234)
 
         mfe.fit(X.values, y.values)

--- a/tests/test_errors_warnings.py
+++ b/tests/test_errors_warnings.py
@@ -78,7 +78,7 @@ class TestErrorsWarnings:
 
     def test_error_folds(self):
         with pytest.raises(ValueError):
-            MFE(folds=1.5)
+            MFE(num_cv_folds=1.5)
 
     def test_error_cat_cols_1(self):
         with pytest.raises(ValueError):

--- a/tests/test_errors_warnings.py
+++ b/tests/test_errors_warnings.py
@@ -17,7 +17,7 @@ class TestErrorsWarnings:
 
     def test_error_sample_size(self):
         with pytest.raises(ValueError):
-            MFE(sample_size=-1)
+            MFE(lm_sample_frac=-1)
 
     def test_error_empty_data_2(self):
         with pytest.raises(TypeError):

--- a/tests/test_landmarking.py
+++ b/tests/test_landmarking.py
@@ -12,7 +12,7 @@ class TestLandmarking():
     """TestClass dedicated to test Landmarking metafeatures."""
 
     @pytest.mark.parametrize(
-        "dt_id, ft_name, exp_value, precompute, sample_size",
+        "dt_id, ft_name, exp_value, precompute, lm_sample_frac",
         [
             ###################
             # Mixed data
@@ -84,7 +84,7 @@ class TestLandmarking():
             (2, 'random_node', [0.5982143, 0.02823461], False, 0.5),
         ])
     def test_ft_methods_landmarking(self, dt_id, ft_name, exp_value,
-                                    precompute, sample_size):
+                                    precompute, lm_sample_frac):
         """Function to test each meta-feature belongs to landmarking group.
         """
         precomp_group = "landmarking" if precompute else None
@@ -93,7 +93,7 @@ class TestLandmarking():
         mfe = MFE(
             groups=["landmarking"],
             features=[ft_name],
-            sample_size=sample_size,
+            lm_sample_frac=lm_sample_frac,
             random_state=1234)
 
         mfe.fit(X.values, y.values, precomp_groups=precomp_group)

--- a/tests/test_relative_landmarking.py
+++ b/tests/test_relative_landmarking.py
@@ -11,7 +11,7 @@ GNAME = "landmarking"
 class TestRelativeLandmarking():
 
     @pytest.mark.parametrize(
-        "dt_id, summary, precompute, sample_size, exp_value",
+        "dt_id, summary, precompute, lm_sample_frac, exp_value",
         [
             #######################################
             # Mean Relative Landmarking
@@ -54,7 +54,7 @@ class TestRelativeLandmarking():
             (2, "sd", True,  0.5, [2.5, 7.0, 4.0, 5.0, 1.0, 2.5, 6.0]),
         ])
     def test_ft_method_relative(self, dt_id, summary, precompute,
-                                sample_size, exp_value):
+                                lm_sample_frac, exp_value):
         """Test relative and subsampling relative landmarking."""
         precomp_group = "relative" if precompute else None
 
@@ -62,7 +62,7 @@ class TestRelativeLandmarking():
         mfe = MFE(
             groups=["relative"],
             summary=summary,
-            sample_size=sample_size,
+            lm_sample_frac=lm_sample_frac,
             random_state=1234)
 
         mfe.fit(X.values, y.values, precomp_groups=precomp_group)
@@ -96,7 +96,7 @@ class TestRelativeLandmarking():
         mfe = MFE(
             groups="all",
             summary=summary,
-            sample_size=0.5,
+            lm_sample_frac=0.5,
             random_state=1234)
 
         mfe.fit(X.values, y.values)


### PR DESCRIPTION
- Improved some variable names in landmarking.py module
- Added option to the user shuffle data before using the Stratified K-Fold CV for the landmarking metafeatures
- Added connection with the CV Splitter and the MFE "random_state" for the case if the user choose to shuffle data before K-Fold CV splits (if the user does not enable shuffling, then the "random_state" will not be used, therefore not producing sklearn warnings.)
- Other small improvements (e.g., initialization of the "result" variables directly as a numpy array instead of a Python list inside a landmarking mtf extraction method, and some extra type annotations in MFE init method)
- Changed MFE argument "sample_size" related to the subsampling landmarking metafeatures to "lm_sample_frac" to both avoid confusion with other metafeature extraction method arguments (e.g., there is a clustering-group method with an argument "sample_size" which is unintendedly affected by this argument, therefore extracting subsampling landmarking metafeatures produce external effects in unrelated metafeatures), and to reflect the fact that this quantity is a percentage (a fraction, "frac") and not a integral number ("size"). 