### PR TITLE
New nan-resilient summary functions

### DIFF
--- a/pymfe/_internal.py
+++ b/pymfe/_internal.py
@@ -920,11 +920,7 @@ def process_summary(
                               summary_func),
                           RuntimeWarning)
         else:
-            try:
-                summary_mtd_args = _extract_mtd_args(summary_mtd_callable)
-
-            except ValueError:
-                summary_mtd_args = tuple()
+            summary_mtd_args = _extract_mtd_args(summary_mtd_callable)
 
             summary_mtd_pack = (
                 summary_func,

--- a/pymfe/_summary.py
+++ b/pymfe/_summary.py
@@ -238,7 +238,7 @@ def sum_kurtosis(values: TypeValList, method: int = 3,
 
 
 def sum_nanstd(values: TypeValList, ddof: int = 1) -> float:
-    """Standard deviation summary function."""
+    """Standard deviation summary function ignoring `nan` values."""
     if len(values) <= ddof:
         return np.nan
 
@@ -254,7 +254,7 @@ def sum_std(values: TypeValList, ddof: int = 1) -> float:
 
 
 def sum_nanvar(values: TypeValList, ddof: int = 1) -> float:
-    """Standard deviation summary function."""
+    """Variance summary function ignoring `nan` values."""
     if len(values) <= ddof:
         return np.nan
 
@@ -262,7 +262,7 @@ def sum_nanvar(values: TypeValList, ddof: int = 1) -> float:
 
 
 def sum_var(values: TypeValList, ddof: int = 1) -> float:
-    """Standard deviation summary function."""
+    """Variance summary function."""
     if len(values) <= ddof:
         return np.nan
 

--- a/pymfe/_summary.py
+++ b/pymfe/_summary.py
@@ -271,7 +271,7 @@ def sum_var(values: TypeValList, ddof: int = 1) -> float:
 
 def sum_nancount(values: TypeValList) -> int:
     """Count how many non-nan element in ``values``."""
-    return len(values) - np.isnan(values).size
+    return len(values) - np.count_nonzero(np.isnan(values))
 
 
 def sum_naniq_range(values: TypeValList) -> float:

--- a/pymfe/_summary.py
+++ b/pymfe/_summary.py
@@ -103,7 +103,7 @@ def sum_quantiles(values: TypeValList,
 
 
 def sum_nanquantiles(values: TypeValList,
-                     numpy_interpolation: str = "linear") -> float:
+                     numpy_interpolation: str = "linear") -> TypeValList:
     """Calculate the ``values`` quantiles, ignoring `nan` values.
 
     The quantiles calculated corresponds to the minimum, maximum,
@@ -176,7 +176,7 @@ def sum_skewness(values: TypeValList, method: int = 3,
 
 
 def sum_kurtosis(values: TypeValList, method: int = 3,
-                 bias: bool = True) -> TypeValList:
+                 bias: bool = True) -> float:
     """Calculate the kurtosis of ``values`` using ``method`` strategy.
 
     Args:
@@ -274,8 +274,8 @@ def sum_nancount(values: TypeValList) -> int:
     return len(values) - np.isnan(values).size
 
 
-def sum_naniq_range(values: TypeValList) -> int:
-    """Count how many non-nan element in ``values``."""
+def sum_naniq_range(values: TypeValList) -> float:
+    """Inter-quartile range (IQR) ignoring `nan` values."""
     return scipy.stats.iqr(values, nan_policy="omit")
 
 
@@ -296,7 +296,7 @@ def sum_nanhistogram(values: TypeValList,
 
 
 def sum_nankurtosis(values: TypeValList, method: int = 3,
-                    bias: bool = True) -> TypeValList:
+                    bias: bool = True) -> float:
     """Estimate data kurtosis ignoring `nan` values."""
     if not isinstance(values, np.ndarray):
         values = np.asarray(values, dtype=float)
@@ -306,7 +306,7 @@ def sum_nankurtosis(values: TypeValList, method: int = 3,
 
 
 def sum_nanskewness(values: TypeValList, method: int = 3,
-                    bias: bool = True) -> TypeValList:
+                    bias: bool = True) -> float:
     """Estimate data skewness ignoring `nan` values."""
     if not isinstance(values, np.ndarray):
         values = np.asarray(values, dtype=float)

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -111,6 +111,13 @@ class MFE:
                 12. ``skewness``: Describes the shape of the measure values
                     distribution in terms of symmetry.
 
+            You can concatenate `nan` with the desired summary function name
+            to use an alternative version of the same summary which ignores
+            `nan` values. For instance, `nanmean` is the `mean` summary
+            function which ignores all `nan` values, while 'naniq_range`
+            is the interquartile range calculated only with valid (non-`nan`)
+            values.
+
             If more than one summary function is selected, then all multivalued
             extracted metafeatures are summarized with each summary function.
 

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -70,6 +70,10 @@ def test_ddof():
     assert np.isnan(pymfe._summary.sum_var(sing_val, ddof=1))
     assert np.isnan(pymfe._summary.sum_std(sing_val, ddof=2))
     assert np.isnan(pymfe._summary.sum_var(sing_val, ddof=2))
+    assert np.isnan(pymfe._summary.sum_nanstd(sing_val, ddof=1))
+    assert np.isnan(pymfe._summary.sum_nanvar(sing_val, ddof=1))
+    assert np.isnan(pymfe._summary.sum_nanstd(sing_val, ddof=2))
+    assert np.isnan(pymfe._summary.sum_nanvar(sing_val, ddof=2))
 
 
 @pytest.mark.parametrize("summary_func", [
@@ -95,16 +99,30 @@ def test_nansummary(summary_func):
     summary_nan = pymfe._summary.SUMMARY_METHODS[summary_func]
     summary_reg = pymfe._summary.SUMMARY_METHODS[summary_func[3:]]
 
-    assert np.allclose(summary_nan(values), summary_reg(clean_values))
+    assert np.allclose(
+        summary_nan(list(values)), summary_reg(list(clean_values)))
 
 
 def test_nancount():
     values = np.array([
-        1, np.nan, np.nan, 2, -4, np.nan, 9, -11, 1, 5, 6.4, 2.3, 4.5, np.nan,
+        1,
+        np.nan,
+        np.nan,
+        2,
+        -4,
+        np.nan,
+        9,
+        -11,
+        1,
+        5,
+        6.4,
+        2.3,
+        4.5,
+        np.nan,
         0,
     ])
     summary_nan = pymfe._summary.SUMMARY_METHODS["nancount"]
     summary_reg = pymfe._summary.SUMMARY_METHODS["count"]
     assert np.allclose(
-        summary_nan(values),
-        summary_reg(values) - np.count_nonzero(np.isnan(values)))
+        summary_nan(list(values)),
+        summary_reg(list(values)) - np.count_nonzero(np.isnan(values)))

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -70,3 +70,41 @@ def test_ddof():
     assert np.isnan(pymfe._summary.sum_var(sing_val, ddof=1))
     assert np.isnan(pymfe._summary.sum_std(sing_val, ddof=2))
     assert np.isnan(pymfe._summary.sum_var(sing_val, ddof=2))
+
+
+@pytest.mark.parametrize("summary_func", [
+    "nanmean",
+    "nansd",
+    "nanvar",
+    "nanhistogram",
+    "naniq_range",
+    "nankurtosis",
+    "nanmax",
+    "nanmedian",
+    "nanmin",
+    "nanquantiles",
+    "nanrange",
+    "nanskewness",
+])
+def test_nansummary(summary_func):
+    values = np.array([
+        1, np.nan, np.nan, 2, -4, np.nan, 9, -11, 1, 5, 6.4, 2.3, 4.5, np.nan,
+        0
+    ])
+    clean_values = values[~np.isnan(values)]
+    summary_nan = pymfe._summary.SUMMARY_METHODS[summary_func]
+    summary_reg = pymfe._summary.SUMMARY_METHODS[summary_func[3:]]
+
+    assert np.allclose(summary_nan(values), summary_reg(clean_values))
+
+
+def test_nancount():
+    values = np.array([
+        1, np.nan, np.nan, 2, -4, np.nan, 9, -11, 1, 5, 6.4, 2.3, 4.5, np.nan,
+        0,
+    ])
+    summary_nan = pymfe._summary.SUMMARY_METHODS["nancount"]
+    summary_reg = pymfe._summary.SUMMARY_METHODS["count"]
+    assert np.allclose(
+        summary_nan(values),
+        summary_reg(values) - np.count_nonzero(np.isnan(values)))


### PR DESCRIPTION
- All summary functions now can be calculated ignoring 'nan' values, using its nan-resilient version.
-- The name of every nan-resilient summary function is 'nan' concatenated with the name of the corresponding summary function.
-- For instance, the nan-resilient version of the 'mean' summary function is 'nanmean', while the nan-resilient version of 'iq_range' is 'naniq_range'.
-- Note that nan-resilient summary functions still can produces 'nan' values. For instance, the 'nansd' calculate the standard deviation ignoring nan values, but it still produces 'nan' as the result of trying to calculate the standard deviation with less or a equal number of observations than the degrees of freedom.