### PR TITLE
Memory issues

### DIFF
--- a/pymfe/_internal.py
+++ b/pymfe/_internal.py
@@ -1202,7 +1202,8 @@ def process_precomp_groups(
         try:
             new_precomp_vals = precomp_mtd_callable(**kwargs)  # type: ignore
 
-        except (AttributeError, TypeError, ValueError, MemoryError) as type_err:
+        except (AttributeError, TypeError,
+                ValueError, MemoryError) as type_err:
             new_precomp_vals = {}
 
             if not suppress_warnings:
@@ -1735,7 +1736,8 @@ def post_processing(
                 for res_list_old, res_list_new in zip(results, new_results):
                     res_list_old += res_list_new
 
-        except (AttributeError, TypeError, ValueError, MemoryError) as type_err:
+        except (AttributeError, TypeError,
+                ValueError, MemoryError) as type_err:
             if not suppress_warnings:
                 warnings.warn("Something went wrong while "
                               "postprocessing '{0}'. Will ignore "

--- a/pymfe/_internal.py
+++ b/pymfe/_internal.py
@@ -540,7 +540,7 @@ def summarize(
     try:
         metafeature = callable_sum(processed_feat, **callable_args)
 
-    except (TypeError, ValueError, ZeroDivisionError):
+    except (TypeError, ValueError, ZeroDivisionError, MemoryError):
         metafeature = np.nan
 
     return metafeature
@@ -580,7 +580,7 @@ def get_feat_value(
     try:
         features = mtd_callable(**mtd_args)
 
-    except (TypeError, ValueError, ZeroDivisionError) as type_e:
+    except (TypeError, ValueError, ZeroDivisionError, MemoryError) as type_e:
         if not suppress_warnings:
             warnings.warn(
                 "Can't extract feature '{0}'.\n Exception message: {1}.\n"
@@ -1202,7 +1202,7 @@ def process_precomp_groups(
         try:
             new_precomp_vals = precomp_mtd_callable(**kwargs)  # type: ignore
 
-        except (AttributeError, TypeError, ValueError) as type_err:
+        except (AttributeError, TypeError, ValueError, MemoryError) as type_err:
             new_precomp_vals = {}
 
             if not suppress_warnings:
@@ -1735,7 +1735,7 @@ def post_processing(
                 for res_list_old, res_list_new in zip(results, new_results):
                     res_list_old += res_list_new
 
-        except (AttributeError, TypeError, ValueError) as type_err:
+        except (AttributeError, TypeError, ValueError, MemoryError) as type_err:
             if not suppress_warnings:
                 warnings.warn("Something went wrong while "
                               "postprocessing '{0}'. Will ignore "

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -11,6 +11,22 @@ from tests.utils import load_xy
 GNAME = "framework-testing"
 
 
+def summary_exception(values: np.ndarray,
+                      raise_exception: bool = False) -> int:
+    if raise_exception:
+        raise ValueError("Summary exception raised.")
+
+    return len(values)
+
+
+def summary_memory_error(values: np.ndarray,
+                         raise_mem_err: bool = False) -> int:
+    if raise_mem_err:
+        aux = np.zeros(int(1e+20), dtype=np.float64)
+
+    return len(values)
+
+
 class MFETestClass:
     """Some generic methods for testing the MFE Framework."""
 
@@ -115,6 +131,42 @@ class MFETestClass:
 
 class TestArchitecture:
     """Tests for the framework architecture."""
+
+    def test_summary_valid1(self):
+        vals = np.arange(5)
+
+        res = _internal.summarize(
+            features=vals, callable_sum=summary_exception)
+
+        assert res == len(vals)
+
+    def test_summary_valid2(self):
+        vals = np.arange(5)
+
+        res = _internal.summarize(
+            features=vals, callable_sum=summary_memory_error)
+
+        assert res == len(vals)
+
+    def test_summary_invalid1(self):
+        res = _internal.summarize(
+            features=np.arange(5),
+            callable_sum=summary_exception,
+            callable_args={
+                "raise_exception": True
+            })
+
+        assert np.isnan(res)
+
+    def test_summary_invalid2(self):
+        res = _internal.summarize(
+            features=np.arange(5),
+            callable_sum=summary_memory_error,
+            callable_args={
+                "raise_mem_err": True
+            })
+
+        assert np.isnan(res)
 
     def test_postprocessing_valid(self):
         """Test valid postprocessing and its automatic detection."""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,10 +1,12 @@
-""" Utils Module.
+"""Utils Module.
 
-    Useful functions to help in the tests.
+Useful functions to help in the tests.
 """
+import typing as t
 
 import arff
 import pandas as pd
+import numpy as np
 
 DATA_ID = [
     "tests/test_datasets/mix_aids.arff",
@@ -19,9 +21,8 @@ DATA_ = [
 ]
 
 
-def load_xy(dt_id):
-    """Returns a dataset loaded from arff file.
-    """
+def load_xy(dt_id: int):
+    """Returns a dataset loaded from arff file."""
     if DATA_[dt_id] is None:
         with open(DATA_ID[dt_id], "r") as data_file:
             data = arff.load(data_file)
@@ -31,3 +32,9 @@ def load_xy(dt_id):
             DATA_[dt_id] = (X, y)
 
     return DATA_[dt_id]
+
+
+def raise_memory_error(
+        size: t.Union[int, float] = 1e+20) -> np.ndarray:
+    """Try to create a huge array, raising a MemoryError."""
+    return np.zeros(int(size), dtype=np.float64)


### PR DESCRIPTION
Resolves #76 .

- Now handling memory errors in precomputations, postcomputations and metafeature extraction as a regular exception.
-- Note that this feature does not prevent memory errors, but prevents the metafeature extraction process from crashing when one memory error happens. The metafeatures that can't be extracted due to memory errors are set as 'np.nan' just like the a regular exceptional scenario.