### PR TITLE
Pydoc fixes and package documentation/code consistency improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,7 @@ python:
     - "3.7-dev"
 
 install:
-    - pip install mypy 
-    - pip install pylint
-    - pip install codecov pytest-cov
-    - pip install .
-    # test dependencies
-    - pip install liac-arff
+    - make install-dev
 
 env:
     global:
@@ -31,6 +26,7 @@ script:
     - mypy $SOURCE_FILES --ignore-missing-imports
     - pylint $SOURCE_FILES -d 'C0103, R0913, R0902, R0914, C0302, R0904, R0801, E1101'
     - pytest tests/ --showlocals -v --cov=pymfe/
+    - make html
 
 notifications:
     email:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ python3 setup.py install
 
 ## Example of use
 
-The simplest way to extract meta-features is instantiating the `MFE` class. The parameters are the measures, the group of measures and the summarization functions to be extracted. The default parameter is extract all the measures. The `fit` function can be called by passing the `X` and `y`. The `extract` function is used to extract the related measures. A simple example is given next:
+The simplest way to extract meta-features is instantiating the `MFE` class. The parameters are the measures, the group of measures and the summarization functions to be extracted. The default parameter is extract all the measures. The `fit` function can be called by passing the `X` and `y`. The `extract` function is used to extract the related measures. A simple example for supervised tasks is given next:
 
 ```python
 # Load a dataset
@@ -74,6 +74,36 @@ print(ft)
 # Extract general, statistical and information-theoretic measures
 mfe = MFE(groups=["general", "statistical", "info-theory"])
 mfe.fit(X, y)
+ft = mfe.extract()
+print(ft)
+
+# Extract all available measures
+mfe = MFE(groups="all")
+mfe.fit(X, y)
+ft = mfe.extract()
+print(ft)
+```
+
+For unsupervised tasks, you can simply omit the target attribute while fitting the data into the MFE model. The `pymfe` package automatically finds and extract only the metafeatures suitable for this type of task. Examples are given next:
+
+```python
+# Load a dataset
+from sklearn.datasets import load_iris
+from pymfe.mfe import MFE
+
+data = load_iris()
+y = data.target
+X = data.data
+
+# Extract default unsupervised measures
+mfe = MFE()
+mfe.fit(X)
+ft = mfe.extract()
+print(ft)
+
+# Extract all available unsupervised measures
+mfe = MFE(groups="all")
+mfe.fit(X)
 ft = mfe.extract()
 print(ft)
 ```
@@ -105,6 +135,31 @@ ft = mfe.extract(
     nr_norm={"method": "all", "failure": "hard", "threshold": 0.025},
     nr_cor_attr={"threshold": 0.6},
 )
+print(ft)
+```
+
+If you want to extract metafeatures from a pre-fitted machine learning model (from `sklearn package`), you can use the `extract_from_model` method, without the need for use the training data:
+
+```python
+import sklearn.tree
+from sklearn.datasets import load_iris
+from pymfe.mfe import MFE
+
+# Extract from model
+iris = load_iris()
+model = sklearn.tree.DecisionTreeClassifier().fit(iris.data, iris.target)
+extractor = MFE()
+ft = extractor.extract_from_model(model)
+print(ft)
+
+# Extract specific metafeatures from model
+extractor = MFE(features=["tree_shape", "nodes_repeated"], summary="histogram")
+
+ft = extractor.extract_from_model(
+    model,
+    arguments_fit={"verbose": 1},
+    arguments_extract={"verbose": 1, "histogram": {"bins": 5}})
+
 print(ft)
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ python3 setup.py install
 
 ## Example of use
 
-The simplest way to extract meta-features is instantiating the `MFE` class. The parameters are the measures, the group of measures and the summarization functions to be extracted. The default parameter is extract all the measures. The `fit` function can be called by passing the `X` and `y`. The `extract` function is used to extract the related measures. A simple example for supervised tasks is given next:
+The simplest way to extract meta-features is by instantiating the `MFE` class. The parameters are the measures, the group of measures, and the summarization functions to be extracted. The default parameter is to extract all the measures. The `fit` function can be called by passing the `X` and `y`. The `extract` function is used to extract the related measures. A simple example using `pymfe` for supervised tasks is given next:
 
 ```python
 # Load a dataset
@@ -84,7 +84,7 @@ ft = mfe.extract()
 print(ft)
 ```
 
-For unsupervised tasks, you can simply omit the target attribute while fitting the data into the MFE model. The `pymfe` package automatically finds and extract only the metafeatures suitable for this type of task. Examples are given next:
+You can simply omit the target attribute for unsupervised tasks while fitting the data into the MFE model. The `pymfe` package automatically finds and extracts only the metafeatures suitable for this type of task. Examples are given next:
 
 ```python
 # Load a dataset
@@ -138,7 +138,7 @@ ft = mfe.extract(
 print(ft)
 ```
 
-If you want to extract metafeatures from a pre-fitted machine learning model (from `sklearn package`), you can use the `extract_from_model` method, without the need for use the training data:
+If you want to extract metafeatures from a pre-fitted machine learning model (from `sklearn package`), you can use the `extract_from_model` method without needing to use the training data:
 
 ```python
 import sklearn.tree

--- a/pymfe/_internal.py
+++ b/pymfe/_internal.py
@@ -73,6 +73,7 @@ import re
 
 import numpy as np
 import sklearn.preprocessing
+import sklearn.tree
 import patsy
 
 import pymfe._summary as _summary
@@ -197,6 +198,11 @@ VERBOSE_BLOCK_MID_SYMBOL = "|"
 VERBOSE_BLOCK_END_SYMBOL = "."
 
 VERBOSE_WARNING_SYMBOL = "*"
+
+type_translator = {
+    sklearn.tree.DecisionTreeClassifier: "dt_model",
+}
+"""'.extract_from_model' supported types and correspoding parameters."""
 
 
 def warning_format(message: str,
@@ -1755,6 +1761,9 @@ def print_verbose_progress(
         item_type: str,
         verbose: int = 0) -> None:
     """Print messages about extraction progress based on ``verbose``."""
+    if verbose <= 0:
+        return
+
     if verbose >= 2:
         print("Done with '{}' {} (progress of {:.2f}%)."
               .format(cur_mtf_name, item_type, cur_progress))

--- a/pymfe/_version.py
+++ b/pymfe/_version.py
@@ -21,4 +21,4 @@ in machine learning and AutoML.
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 
-__version__ = '0.2.0'
+__version__ = '0.3.a0'

--- a/pymfe/clustering.py
+++ b/pymfe/clustering.py
@@ -66,7 +66,7 @@ class MFEClustering:
         Parameters
         ----------
         y : :obj:`np.ndarray`, optional
-            Target attribute from fitted data.
+            Instance cluster index (or target attribute).
 
         **kwargs
             Additional arguments. May have previously precomputed before
@@ -114,15 +114,15 @@ class MFEClustering:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Numerical attributes from fitted data.
+            Numerical fitted data.
 
         y : :obj:`np.ndarray`, optional
-            Target attribute from fitted data.
+            Instance cluster index (or target attribute).
 
         dist_metric : str, optional
             The distance metric used to calculate the distances between
-            instances. Check `distmetric`_ for a full list of valid
-            distance metrics.
+            instances. Check :obj:`sklearn.neighbors.DistanceMetric`
+            documentation for a full list of valid distance metrics.
 
         classes : :obj:`np.ndarray`, optional
             Distinct classes in ``y``. Used to exploit precomputations.
@@ -155,11 +155,6 @@ class MFEClustering:
               indicates whether each example belongs to each class. The
               rows represents the distinct classes, and the instances
               are represented by the columns.
-
-        Notes
-        -----
-            .. _distmetric: :obj:`sklearn.neighbors.DistanceMetric`
-              documentation.
         """
         precomp_vals = {}
 
@@ -216,18 +211,18 @@ class MFEClustering:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Numerical attributes from fitted data.
+            Numerical fitted data.
 
         y : :obj:`np.ndarray`, optional
-            Target attribute from fitted data.
+            Instance cluster index (or target attribute).
 
         n_neighbors : int, optional
             Number of nearest neighbors returned for each instance.
 
         dist_metric : str, optional
             The distance metric used to calculate the distances between
-            instances. Check `distmetric`_ for a full list of valid
-            distance metrics.
+            instances. Check :obj:`sklearn.neighbors.DistanceMetric`
+            documentation for a full list of valid distance metrics.
 
         **kwargs
             Additional arguments. May have previously precomputed before
@@ -241,11 +236,6 @@ class MFEClustering:
                 * ``pairwise_intraclass_dists`` (:obj:`np.ndarray`):
                   distance between each distinct pair of instances of
                   the same class.
-
-        Notes
-        -----
-            .. _distmetric: :obj:`sklearn.neighbors.DistanceMetric`
-                documentation.
         """
         precomp_vals = {}
 
@@ -277,15 +267,15 @@ class MFEClustering:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Numerical attributes from fitted data.
+            Numerical fitted data.
 
         y : :obj:`np.ndarray`, optional
-            Target attribute from fitted data.
+            Instance cluster index (or target attribute).
 
         dist_metric : str, optional
             The distance metric used to calculate the distances between
-            instances. Check `distmetric`_ for a full list of valid
-            distance metrics.
+            instances. Check :obj:`sklearn.neighbors.DistanceMetric`
+            documentation for a full list of valid distance metrics.
 
         representative : str or :obj:`np.ndarray` or Sequence, optional
             * If representative is string-type, then it must assume one
@@ -326,11 +316,6 @@ class MFEClustering:
                 * ``pairwise_intraclass_dists`` (:obj:`np.ndarray`):
                   distance between each distinct pair of instances of
                   the same class.
-
-        Notes
-        -----
-            .. _distmetric: :obj:`sklearn.neighbors.DistanceMetric`
-                documentation.
         """
         precomp_vals = {}
 
@@ -527,14 +512,15 @@ class MFEClustering:
         N : :obj:`np.ndarray`
             Attributes from fitted data.
 
-        y : :obj:`np.ndarray`, optional
-            Target attribute from fitted data.
+        y : :obj:`np.ndarray`
+            Instance cluster index (or target attribute).
 
         dist_metric : str, optional
             The distance metric used to calculate the distances between
-            instances. Check `scipydoc`_ for a full list of valid distance
-            metrics. If precomputation in clustering metafeatures is
-            enabled, then this parameter takes no effect.
+            instances. Check :obj:`scipy.spatial.distance` documentation
+            for a full list of valid distance metrics. If precomputation
+            in clustering metafeatures is enabled, then this parameter
+            takes no effect.
 
         cls_inds : :obj:`np.ndarray`, optional
             Boolean array which indicates the examples of each class.
@@ -555,12 +541,8 @@ class MFEClustering:
 
         Returns
         -------
-        :obj:`float`
+        float
             Dunn index for given parameters.
-
-        Notes
-        -----
-        .. _scipydoc: :obj:`scipy.spatial.distance` documentation.
 
         References
         ----------
@@ -595,20 +577,16 @@ class MFEClustering:
 
         Metric range is 0 (inclusive) and infinity.
 
-        Check `dbindex`_ for more information.
+        Check :obj:`sklearn.metrics.davies_bouldin_score` documentation
+        for more information.
 
         Parameters
         ----------
         N : :obj:`np.ndarray`
             Attributes from fitted data.
 
-        y : :obj:`np.ndarray`, optional
-            Target attribute from fitted data.
-
-        Notes
-        -----
-        .. _dbindex: :obj:``sklearn.metrics.davies_bouldin_score``
-           documentation.
+        y : :obj:`np.ndarray`
+            Instance cluster index (or target attribute).
 
         References
         ----------
@@ -636,14 +614,15 @@ class MFEClustering:
         N : :obj:`np.ndarray`
             Attributes from fitted data.
 
-        y : :obj:`np.ndarray`, optional
-            Target attribute from fitted data.
+        y : :obj:`np.ndarray`
+            Instance cluster index (or target attribute).
 
         dist_metric : str, optional
             The distance metric used to calculate the distances between
-            instances. Check `scipydoc`_ for a full list of valid distance
-            metrics. If precomputation in clustering metafeatures is
-            enabled, then this parameter takes no effect.
+            instances. Check :obj:`scipy.spatial.distance` documentation
+            for a full list of valid distance metrics. If precomputation
+            in clustering metafeatures is enabled, then this parameter
+            takes no effect.
 
         cls_inds : :obj:`np.ndarray`, optional
             Boolean array which indicates the examples of each class.
@@ -660,12 +639,8 @@ class MFEClustering:
 
         Returns
         -------
-        :obj:`float`
+        float
             INT index.
-
-        Notes
-        -----
-            .. _scipydoc: :obj:`scipy.spatial.distance` documentation.
 
         References
         ----------
@@ -706,20 +681,21 @@ class MFEClustering:
 
         Metric range is -1 to +1 (both inclusive).
 
-        Check `silhouette`_ for more information.
+        Check :obj:`sklearn.metrics.silhouette_score` documentation for
+        more information.
 
         Parameters
         ----------
         N : :obj:`np.ndarray`
             Attributes from fitted data.
 
-        y : :obj:`np.ndarray`, optional
-            Target attribute from fitted data.
+        y : :obj:`np.ndarray`
+            Instance cluster index (or target attribute).
 
         dist_metric : str, optional
             The distance metric used to calculate the distances between
-            instances. Check `distmetric`_ for a full list of valid
-            distance metrics.
+            instances. Check :obj:`sklearn.neighbors.DistanceMetric`
+            documentation for a full list of valid distance metrics.
 
         sample_frac : int, optional
             Sample fraction used to compute the silhouette coefficient. If
@@ -731,15 +707,8 @@ class MFEClustering:
 
         Returns
         -------
-        :obj:`float`
+        float
             Mean Silhouette value.
-
-        Notes
-        -----
-            .. _silhouette: :obj:`sklearn.metrics.silhouette_score`
-                documentation.
-            .. _distmetric: :obj:`sklearn.neighbors.DistanceMetric`
-                documentation.
 
         References
         ----------
@@ -778,22 +747,18 @@ class MFEClustering:
         N : :obj:`np.ndarray`
             Attributes from fitted data.
 
-        y : :obj:`np.ndarray`, optional
-            Target attribute from fitted data.
+        y : :obj:`np.ndarray`
+            Instance cluster index (or target attribute).
 
         dist_metric : str, optional
             The distance metric used to calculate the distances between
-            instances. Check `scipydoc`_ for a full list of valid distance
-            metrics.
+            instances. Check :obj:`scipy.spatial.distance` for a full
+            list of valid distance metrics.
 
         Returns
         -------
-        :obj:`float`
+        float
             Point Biserial coefficient.
-
-        Notes
-        -----
-            .. _scipydoc: :obj:`scipy.spatial.distance` documentation.
 
         References
         ----------
@@ -817,25 +782,21 @@ class MFEClustering:
     def ft_ch(cls, N: np.ndarray, y: np.ndarray) -> float:
         """Compute the Calinski and Harabasz index.
 
-        Check `cahascore`_ for more information.
+        Check :obj:`sklearn.metrics.calinski_harabasz_score` documentation
+        for more information.
 
         Parameters
         ----------
         N : :obj:`np.ndarray`
             Attributes from fitted data.
 
-        y : :obj:`np.ndarray`, optional
-            Target attribute from fitted data.
+        y : :obj:`np.ndarray`
+            Instance cluster index (or target attribute).
 
         Returns
         -------
-        :obj:`float`
+        float
             Calinski-Harabasz index.
-
-        Notes
-        -----
-            .. _cahascore: ``sklearn.metrics.calinski_harabasz_score``
-                documentation.
 
         References
         ----------
@@ -856,15 +817,15 @@ class MFEClustering:
 
         Parameters
         ----------
-        y : :obj:`np.ndarray`, optional
-            Target attribute from fitted data.
+        y : :obj:`np.ndarray`
+            Instance cluster index (or target attribute).
 
-        class_freqs : :obj:`np.ndarray`
+        class_freqs : :obj:`np.ndarray`, optional
             Absolute class frequencies. Used to exploit precomputations.
 
         Returns
         -------
-        :obj:`float`
+        float
             Entropy of relative class frequencies.
 
         References
@@ -882,32 +843,34 @@ class MFEClustering:
         return scipy.stats.entropy(class_freqs / num_inst)
 
     @classmethod
-    def ft_sc(cls,
-              y: np.ndarray,
-              size: int = 15,
-              class_freqs: t.Optional[np.ndarray] = None,
-              normalize: bool = False) -> int:
+    def ft_sc(
+            cls,
+            y: np.ndarray,
+            size: int = 15,
+            normalize: bool = False,
+            class_freqs: t.Optional[np.ndarray] = None,
+    ) -> int:
         """Compute the number of clusters with size smaller than a given size.
 
         Parameters
         ----------
-        y : :obj:`np.ndarray`, optional
-            Target attribute from fitted data.
+        y : :obj:`np.ndarray`
+            Instance cluster index (or target attribute).
 
         size : int, optional
             Maximum (exclusive) size of classes to be considered.
-
-        class_freqs : :obj:`np.ndarray`, optional
-            Class (absolute) frequencies. Used to exploit precomputations.
 
         normalize : bool, optional
             If True, then the result will be the proportion of classes
             with less than ``size`` instances from the total of classes.
             (i.e., result is divided by the number of classes.)
 
+        class_freqs : :obj:`np.ndarray`, optional
+            Class (absolute) frequencies. Used to exploit precomputations.
+
         Returns
         -------
-        :obj:`int` or :obj:`float`
+        int or float
             Number of classes with less than ``size`` instances if
             ``normalize`` is False, proportion of classes with less
             than ``size`` instances otherwise.

--- a/pymfe/complexity.py
+++ b/pymfe/complexity.py
@@ -59,14 +59,14 @@ class MFEComplexity:
     """
 
     @classmethod
-    def precompute_fx(cls, y: t.Optional[np.ndarray] = None,
-                      **kwargs) -> t.Dict[str, t.Any]:
+    def precompute_complexity(cls, y: t.Optional[np.ndarray] = None,
+                              **kwargs) -> t.Dict[str, t.Any]:
         """Precompute some useful things to support feature-based measures.
 
         Parameters
         ----------
         y : :obj:`np.ndarray`, optional
-            Target attribute from fitted data.
+            Target attribute.
 
         **kwargs
             Additional arguments. May have previously precomputed before this
@@ -118,7 +118,7 @@ class MFEComplexity:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Numerical fitted data.
 
         tx_n_components : float, optional
             Specifies the number of components such that the amount of variance
@@ -220,10 +220,10 @@ class MFEComplexity:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Numerical fitted data.
 
         y : :obj:`np.ndarray`
-            Fitted target attribute.
+            Target attribute.
 
         ovo_comb : :obj:`np.ndarray`, optional
             List of all class OVO combination, i.e., all combinations of
@@ -253,7 +253,7 @@ class MFEComplexity:
            Volume 52 Issue 5, October 2019, Article No. 107.
         """
         if ovo_comb is None or cls_inds is None or class_freqs is None:
-            sub_dic = cls.precompute_fx(y=y)
+            sub_dic = cls.precompute_complexity(y=y)
             ovo_comb = sub_dic["ovo_comb"]
             cls_inds = sub_dic["cls_inds"]
             class_freqs = sub_dic["class_freqs"]
@@ -291,10 +291,10 @@ class MFEComplexity:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Numerical fitted data.
 
         y : :obj:`np.ndarray`
-            Fitted target attribute.
+            Target attribute.
 
         ovo_comb : :obj:`np.ndarray`, optional
             List of all class OVO combination, i.e., all combinations of
@@ -324,7 +324,7 @@ class MFEComplexity:
            Volume 52 Issue 5, October 2019, Article No. 107.
         """
         if ovo_comb is None or cls_inds is None or class_freqs is None:
-            sub_dic = cls.precompute_fx(y=y)
+            sub_dic = cls.precompute_complexity(y=y)
             ovo_comb = sub_dic["ovo_comb"]
             cls_inds = sub_dic["cls_inds"]
             class_freqs = sub_dic["class_freqs"]
@@ -384,10 +384,10 @@ class MFEComplexity:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Numerical fitted data.
 
         y : :obj:`np.ndarray`
-            Fitted target attribute.
+            Target attribute.
 
         ovo_comb : :obj:`np.ndarray`, optional
             List of all class OVO combination, i.e., all combinations of
@@ -419,7 +419,7 @@ class MFEComplexity:
            Volume 52 Issue 5, October 2019, Article No. 107.
         """
         if ovo_comb is None or cls_inds is None:
-            sub_dic = cls.precompute_fx(y=y)
+            sub_dic = cls.precompute_complexity(y=y)
             ovo_comb = sub_dic["ovo_comb"]
             cls_inds = sub_dic["cls_inds"]
 
@@ -460,10 +460,10 @@ class MFEComplexity:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Numerical fitted data.
 
         y : :obj:`np.ndarray`
-            Fitted target attribute.
+            Target attribute.
 
         metric : str, optional
             Metric used to calculate the distances between the instances.
@@ -527,10 +527,10 @@ class MFEComplexity:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Numerical fitted data.
 
         y : :obj:`np.ndarray`
-            Target attribute from fitted data.
+            Target attribute.
 
         cls_inds : :obj:`np.ndarray`, optional
             Boolean array which indicates the examples of each class.
@@ -625,7 +625,7 @@ class MFEComplexity:
         Parameters
         ----------
         y : :obj:`np.ndarray`
-            Target attribute from fitted data.
+            Target attribute.
 
         class_freqs : :obj:`np.ndarray`, optional
             The number of examples in each class. The indices represent
@@ -664,7 +664,7 @@ class MFEComplexity:
         Parameters
         ----------
         y : :obj:`np.ndarray`
-            Target attribute from fitted data.
+            Target attribute.
 
         class_freqs : :obj:`np.ndarray`, optional
             The number of examples in each class. The indices represent
@@ -738,7 +738,7 @@ class MFEComplexity:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Numerical fitted data.
 
         num_attr_pca : int, optional
             Number of features after PCA where a fraction of at least 0.95
@@ -786,7 +786,7 @@ class MFEComplexity:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Numerical fitted data.
 
         num_attr_pca : int, optional
             Number of features after PCA where a fraction of at least 0.95

--- a/pymfe/concept.py
+++ b/pymfe/concept.py
@@ -62,9 +62,9 @@ class MFEConcept:
         Parameters
         ----------
         N : :obj:`np.ndarray`, optional
-            Attributes from fitted data.
+            Numerical fitted data.
 
-        concept_dist_metric : str
+        concept_dist_metric : str, optional
             Metric used to compute distance between each pair of examples. See
             cdist from scipy for more options.
 
@@ -111,10 +111,10 @@ class MFEConcept:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Numerical fitted data.
 
-        y : :obj:`np.ndarray`, optional
-            Target attribute from fitted data.
+        y : :obj:`np.ndarray`
+            Target attribute.
 
         conceptvar_alpha : float, optional
             The alpha value to adjust the weight. The higher the alpha less
@@ -184,7 +184,7 @@ class MFEConcept:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Numerical fitted data.
 
         wg_dist_alpha : float, optional
             The alpha value to adjust the weight. The higher the alpha less
@@ -249,10 +249,10 @@ class MFEConcept:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Numerical fitted data.
 
-        y : :obj:`np.ndarray`, optional
-            Target attribute from fitted data.
+        y : :obj:`np.ndarray`
+            Target attribute.
 
         impconceptvar_alpha : float, optional
             The alpha value to adjust the weight. The higher the alpha less
@@ -313,7 +313,7 @@ class MFEConcept:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Numerical fitted data.
 
         cohesiveness_alpha : float, optional
             The alpha value to adjust the weight. The higher the alpha less

--- a/pymfe/general.py
+++ b/pymfe/general.py
@@ -58,7 +58,7 @@ class MFEGeneral:
         Parameters
         ----------
         y : :obj:`np.ndarray`
-            Target attribute from fitted data.
+            Target attribute.
 
         **kwargs
             Additional arguments. May have previously precomputed before
@@ -92,8 +92,8 @@ class MFEGeneral:
 
         Parameters
         ----------
-        X : :obj:`np.ndarray`, optional
-            Attributes from fitted data.
+        X : :obj:`np.ndarray`
+            Fitted data.
 
         Returns
         -------
@@ -122,16 +122,16 @@ class MFEGeneral:
 
         Parameters
         ----------
-        X : :obj:`np.ndarray`, optional
-            Attributes from fitted data.
+        X : :obj:`np.ndarray`
+            Fitted data.
 
-        cat_cols : :obj:`list`
+        cat_cols : :obj:`list` of int
             Sequence containing the indices of each categorical column
             in ``X``.
 
         Returns
         -------
-        int | float
+        int or float
             Proportion of categorical and numerical attributes.
 
         References
@@ -149,16 +149,17 @@ class MFEGeneral:
         return num_cat / (X.shape[1] - num_cat)
 
     @classmethod
-    def ft_freq_class(cls,
-                      y: np.ndarray,
-                      class_freqs: t.Optional[np.ndarray] = None
-                      ) -> np.ndarray:
+    def ft_freq_class(
+            cls,
+            y: np.ndarray,
+            class_freqs: t.Optional[np.ndarray] = None,
+    ) -> np.ndarray:
         """Compute the relative frequency of each distinct class.
 
         Parameters
         ----------
         y : :obj:`np.ndarray`
-            Target attribute from fitted data.
+            Target attribute.
 
         class_freqs : :obj:`np.ndarray`, optional
             Absolute frequency of each distinct class. Argument
@@ -192,8 +193,8 @@ class MFEGeneral:
 
         Parameters
         ----------
-        X : :obj:`np.ndarray`, optional
-            Attributes from fitted data.
+        X : :obj:`np.ndarray`
+            Fitted data.
 
         Returns
         -------
@@ -215,8 +216,8 @@ class MFEGeneral:
 
         Parameters
         ----------
-        X : :obj:`np.ndarray`, optional
-            Attributes from fitted data.
+        X : :obj:`np.ndarray`
+            Fitted data.
 
         Returns
         -------
@@ -240,8 +241,8 @@ class MFEGeneral:
 
         Parameters
         ----------
-        X : :obj:`np.ndarray`, optional
-            Attributes from fitted data.
+        X : :obj:`np.ndarray`
+            Fitted data.
 
         Returns
         -------
@@ -265,7 +266,7 @@ class MFEGeneral:
 
         Parameters
         ----------
-        cat_cols : list
+        cat_cols : :obj:`list` of int
             Sequence containing the indices of each categorical column
             in ``X``.
 
@@ -284,16 +285,14 @@ class MFEGeneral:
         return len(cat_cols)
 
     @classmethod
-    def ft_nr_class(
-            cls,
-            y: np.ndarray,
-            classes: t.Optional[np.ndarray] = None) -> int:
+    def ft_nr_class(cls, y: np.ndarray,
+                    classes: t.Optional[np.ndarray] = None) -> int:
         """Compute the number of distinct classes.
 
         Parameters
         ----------
         y : :obj:`np.ndarray`
-            Target attribute from fitted data.
+            Target attribute.
 
         classes : :obj:`np.ndarray`, optional
             Array with all distinct classes. This argument purpose is
@@ -321,8 +320,8 @@ class MFEGeneral:
 
         Parameters
         ----------
-        X : :obj:`np.ndarray`, optional
-            Attributes from fitted data.
+        X : :obj:`np.ndarray`
+            Fitted data.
 
         Returns
         -------
@@ -343,10 +342,10 @@ class MFEGeneral:
 
         Parameters
         ----------
-        X : :obj:`np.ndarray`, optional
-            Attributes from fitted data.
+        X : :obj:`np.ndarray`
+            Fitted data.
 
-        cat_cols : list
+        cat_cols : :obj:`list` of int
             Sequence containing the indices of each categorical column
             in ``X``.
 
@@ -376,16 +375,16 @@ class MFEGeneral:
 
         Parameters
         ----------
-        X : :obj:`np.ndarray`, optional
-            Attributes from fitted data.
+        X : :obj:`np.ndarray`
+            Fitted data.
 
-        cat_cols : :obj:`list`
+        cat_cols : :obj:`list` of int
             Sequence containing the indices of each categorical column
             in ``X``.
 
         Returns
         -------
-        int | float
+        int or float
             If ``X`` has at least one categorical feature, then return the
             ratio of numerical and categorical features. Return :obj:`np.nan`
             otherwise.

--- a/pymfe/info_theory.py
+++ b/pymfe/info_theory.py
@@ -61,7 +61,7 @@ class MFEInfoTheory:
         Parameters
         ----------
         y : :obj:`np.ndarray`, optional
-            The target attribute vector.
+            Target attribute.
 
         kwargs:
             Additional arguments. May have previously precomputed before this
@@ -96,10 +96,10 @@ class MFEInfoTheory:
         Parameters
         ----------
         C : :obj:`np.ndarray`
-            Categorical attributes from fitted data.
+            Categorical fitted data.
 
         y : :obj:`np.ndarray`
-            The target attribute vector.
+            Target attribute.
 
         class_freqs : :obj:`np.ndarray`, optional
             Absolute frequency of each distinct class in ``y``.
@@ -113,7 +113,7 @@ class MFEInfoTheory:
         -------
         :obj:`dict`
             With following precomputed items:
-                - ``class_ent`` (:obj:`float`): Shannon's Entropy of ``y``, if
+                - ``class_ent`` (float): Shannon's Entropy of ``y``, if
                   it is not :obj:`NoneType`.
                 - ``attr_ent`` (:obj:`np.ndarray`): Shannon's Entropy of each
                   attribute in ``C``, if it is not :obj:`NoneType`.
@@ -173,7 +173,7 @@ class MFEInfoTheory:
                         vec_x: np.ndarray,
                         vec_y: np.ndarray,
                         epsilon: float = 1.0e-8) -> float:
-        """Compute joint entropy between vectorx ``x`` and ``y``."""
+        """Compute joint entropy between vectorx `x` and ``y``."""
         joint_prob_mat = pd.crosstab(
             vec_y, vec_x, normalize=True).values + epsilon
 
@@ -210,7 +210,7 @@ class MFEInfoTheory:
         Parameters
         ----------
         C : :obj:`np.ndarray`
-            Categorical attributes from fitted data.
+            Categorical fitted data.
 
         max_attr_num : int, optional
             Maximum number of attributes considered. If ``C`` has more
@@ -266,14 +266,14 @@ class MFEInfoTheory:
 
             H(x) = - sum_{val in phi_x}(P(x = val) * log2(P(x = val))
 
-        Where ``phi_x`` is a set of all possible distinct values in vector
-        ``x`` and P(x = val) is the probability of x assume some value ``val``
-        in phi_x.
+        Where `phi_x` is a set of all possible distinct values in vector
+        `x` and P(x = val) is the probability of x assume some value `val`
+        in `phi_x`.
 
         Parameters
         ----------
         C : :obj:`np.ndarray`
-            Categorical attributes from fitted data.
+            Categorical fitted data.
 
         attr_ent : :obj:`np.ndarray`, optional
             This argument is this method own return value, meant to exploit
@@ -306,10 +306,10 @@ class MFEInfoTheory:
         Parameters
         ----------
         C : :obj:`np.ndarray`
-            Categorical attributes from fitted data.
+            Categorical fitted data.
 
         y : :obj:`np.ndarray`
-            The target attribute vector.
+            Target attribute.
 
         Returns
         -------
@@ -337,14 +337,14 @@ class MFEInfoTheory:
 
             H(y) = - sum_{val in phi_y}(P(y = val) * log2(P(y = val))
 
-        Where ``phi_y`` is a set of all possible distinct values in vector
-        ``y`` and P(y = val) is the probability of y assume some value ``val``
-        in phi_y.
+        Where `phi_y` is a set of all possible distinct values in vector
+        ``y`` and P(y = val) is the probability of y assume some value `val`
+        in `phi_y`.
 
         Parameters
         ----------
         y : :obj:`np.ndarray`
-            The target attribute vector.
+            Target attribute.
 
         class_ent : float, optional
             Entropy of the target attribute ``y``. Used to explot
@@ -358,7 +358,7 @@ class MFEInfoTheory:
 
         Returns
         -------
-        :obj:`float`
+        float
             Entropy of the target attribute.
 
         References
@@ -386,16 +386,16 @@ class MFEInfoTheory:
             E = attr_num * (H(y) / sum_x(MI(x, y)))
 
         Where H(y) is the Shannon's Entropy of the target attribute and MI(x,y)
-        is the Mutual Information between the predictive attribute ``x`` and
+        is the Mutual Information between the predictive attribute `x` and
         target attribute ``y``.
 
         Parameters
         ----------
         C : :obj:`np.ndarray`
-            Categorical attributes from fitted data.
+            Categorical fitted data.
 
         y : :obj:`np.ndarray`
-            The target attribute vector.
+            Target attribute.
 
         class_ent : float, optional
             Entropy of the target attribute ``y``. Used to explot
@@ -416,7 +416,7 @@ class MFEInfoTheory:
 
         Returns
         -------
-        :obj:`float`
+        float
             Estimated number of equivalent predictive attributes.
 
         References
@@ -442,27 +442,27 @@ class MFEInfoTheory:
                      joint_ent: t.Optional[np.ndarray] = None) -> np.ndarray:
         """Compute the joint entropy between each attribute and class.
 
-        The Joint Entropy H between a predictive attribute x and target attri-
-        bute ``y`` is defined as:
+        The Joint Entropy H between a predictive attribute x and target
+        attribute ``y`` is defined as:
 
             H(x, y) = - sum_{phi_x}(sum_{phi_y}(p_i_j * log2(p_i_j)))
 
-        Where ``phi_x`` and ``phi_y`` are sets of possible distinct values for,
-        respectively, ``x`` and ``y`` and ``p_i_j`` is defined as:
+        Where `phi_x` and `phi_y` are sets of possible distinct values for,
+        respectively, `x` and ``y`` and `p_i_j` is defined as:
 
             p_i_j = P(x = phi_x_i, y = phi_y_j)
 
-        That is, ``p_i_j`` is the joint probability of ``x`` to assume a speci-
-        fic value ``i`` in the set ``phi_x`` simultaneously with ``y`` assuming
-        a specific value ``j`` in the set ``phi_y``.
+        That is, `p_i_j` is the joint probability of `x` to assume a specific
+        value `i` in the set `phi_x` simultaneously with ``y`` assuming a
+        specific value `j` in the set `phi_y`.
 
         Parameters
         ----------
         C : :obj:`np.ndarray`
-            Categorical attributes from fitted data.
+            Categorical fitted data.
 
         y : :obj:`np.ndarray`
-            The target attribute vector.
+            Target attribute.
 
         joint_ent : :obj:`np.ndarray`, optional
             This argument is this method own return value, meant to exploit
@@ -497,23 +497,23 @@ class MFEInfoTheory:
                    class_freqs: t.Optional[np.ndarray] = None) -> np.ndarray:
         """Compute the mutual information between each attribute and target.
 
-        The mutual Information MI between an independent attribute ``x`` and
+        The mutual Information MI between an independent attribute `x` and
         target attribute ``y`` is defined as:
 
             MI(x, y) = H(x) + H(y) - H(x, y)
 
-        Where H(x) and H(y) are, respectively, the Shannon's Entropy (see do-
-        dumentation of `ft_attr_ent`` or ``ft_class_ent`` for more informati-
-        on) for ``x`` and ``y`` and H(x, y) is the joint entropy between ``x``
-        and ``y`` (see ``ft_joint_ent`` documentation more details).
+        Where H(x) and H(y) are, respectively, the Shannon's Entropy (see the
+        documentation of ``ft_attr_ent`` or ``ft_class_ent`` for more
+        information) for `x` and ``y`` and H(x, y) is the joint entropy of
+        `x` and ``y`` (see ``ft_joint_ent`` documentation more details.)
 
         Parameters
         ----------
         C : :obj:`np.ndarray`
-            Categorical attributes from fitted data.
+            Categorical fitted data.
 
         y : :obj:`np.ndarray`
-            The target attribute vector.
+            Target attribute.
 
         mut_inf : :obj:`np.ndarray`, optional
             This argument is this method own return value, meant to exploit
@@ -525,7 +525,7 @@ class MFEInfoTheory:
             :obj:`NoneType`, this argument is calculated using ``ft_attr_ent``
             method.
 
-        class_ent : :obj:`float`, optional
+        class_ent : float, optional
             Entropy of the target attribute ``y``. Used to explot
             precomputations. If :obj:`NoneType`, this argument is calculated
             using the method ``ft_class_ent``.
@@ -572,22 +572,22 @@ class MFEInfoTheory:
                     mut_inf: t.Optional[np.ndarray] = None) -> float:
         """Compute the noisiness of attributes.
 
-        Let ``y`` be a target attribute and ``x`` one predictive attribute in
+        Let ``y`` be a target attribute and `x` one predictive attribute in
         a dataset ``N``. Noisiness ``N`` is defined as:
 
             N = (sum_x(attr_entropy(x)) - sum_x(MI(x, y))) / sum_x(MI(x, y))
 
         where MI(x, y) is the mutual information between target attribute ``y``
-        and predictive attribute ``x``, and all ``sum`` is performed for all
-        distinct ``x`` in ``N``.
+        and predictive attribute `x`, and all `sum` is performed over each
+        distinct attribute `x` in ``N``.
 
         Parameters
         ----------
         C : :obj:`np.ndarray`
-            Categorical attributes from fitted data.
+            Categorical fitted data.
 
         y : :obj:`np.ndarray`
-            The target attribute vector.
+            Target attribute.
 
         attr_ent : :obj:`np.ndarray`, optional
             Values of each attribute entropy in ``N``. This argument purpose is
@@ -604,7 +604,7 @@ class MFEInfoTheory:
 
         Returns
         -------
-        :obj:`float`
+        float
             Estimated noisiness of the predictive attributes.
 
         References

--- a/pymfe/info_theory.py
+++ b/pymfe/info_theory.py
@@ -173,7 +173,7 @@ class MFEInfoTheory:
                         vec_x: np.ndarray,
                         vec_y: np.ndarray,
                         epsilon: float = 1.0e-8) -> float:
-        """Compute joint entropy between vectorx `x` and ``y``."""
+        """Compute joint entropy between ``vec_x`` and ``vec_y``."""
         joint_prob_mat = pd.crosstab(
             vec_y, vec_x, normalize=True).values + epsilon
 
@@ -187,7 +187,8 @@ class MFEInfoTheory:
                    vec_x: np.ndarray,
                    vec_y: np.ndarray,
                    epsilon: float = 1.0e-8) -> float:
-        """Concentration coefficient between two arrays ``vec_x`` and ``vec_y``.
+        """Concentration coefficient between two arrays ``vec_x`` and
+        ``vec_y``.
 
         Used for methods ``ft_class_conc`` and ``ft_attr_conc``.
         """

--- a/pymfe/itemset.py
+++ b/pymfe/itemset.py
@@ -58,7 +58,7 @@ class MFEItemset:
         Parameters
         ----------
         C : :obj:`np.ndarray`, optional
-            Attributes from fitted data.
+            Categorical fitted data.
 
         **kwargs
             Additional arguments. May have previously precomputed before this
@@ -109,9 +109,9 @@ class MFEItemset:
         Parameters
         ----------
         C : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Categorical fitted data.
 
-        itemset_binary_matrix : :obj:`list`
+        itemset_binary_matrix : :obj:`list` of :obj:`np.ndarray`, optional
             Binary representation of the attributes. Each list value has a
             binary representation of each attributes in the dataset.
 
@@ -159,9 +159,9 @@ class MFEItemset:
         Parameters
         ----------
         C : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Categorical fitted data.
 
-        itemset_binary_matrix : :obj:`list`
+        itemset_binary_matrix : :obj:`list` of :obj:`np.ndarray`, optional
             Binary representation of the attributes. Each list value has a
             binary representation of each attributes in the dataset.
 

--- a/pymfe/landmarking.py
+++ b/pymfe/landmarking.py
@@ -64,7 +64,7 @@ class MFELandmarking:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Numerical fitted data.
 
         lm_sample_frac : float
             The percentage of examples subsampled. Value different from default
@@ -72,10 +72,8 @@ class MFELandmarking:
             metafeatures.
 
         random_state : int, optional
-            If int, random_state is the seed used by the random number
-            generator; If RandomState instance, random_state is the random
-            number generator; If None, the random number generator is the
-            RandomState instance used by np.random.
+            If given, set the random seed before any pseudo-random calculations
+            to keep the experiments reproducible.
 
         Returns
         -------
@@ -89,7 +87,7 @@ class MFELandmarking:
         """
         precomp_vals = {}
 
-        if N is not None and "sample_inds" not in kwargs:
+        if N is not None and N.size > 0 and "sample_inds" not in kwargs:
             if lm_sample_frac < 1.0:
                 num_inst, _ = N.shape
 
@@ -115,23 +113,21 @@ class MFELandmarking:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Numerical fitted data.
 
         y : :obj:`np.ndarray`, optional
-            Fitted target attribute.
+            Target attribute.
 
         num_cv_folds : int, optional
-            Number of num_cv_folds to k-fold cross validation.
+            Number of folds to k-fold cross validation.
 
         shuffle_cv_folds : bool, optional
             If True, shuffle the samples before splitting the k-fold cross
             validation.
 
         random_state : int, optional
-            If int, random_state is the seed used by the random number
-            generator; If RandomState instance, random_state is the random
-            number generator; If None, the random number generator is the
-            RandomState instance used by np.random.
+            If given, set the random seed before any pseudo-random calculations
+            to keep the experiments reproducible.
 
         lm_sample_frac : float, optional
             The percentage of examples subsampled. Value different from default
@@ -154,7 +150,7 @@ class MFELandmarking:
         """
         precomp_vals = {}
 
-        if N is not None and y is not None:
+        if N is not None and N.size > 0 and y is not None:
             if "skf" not in kwargs:
                 precomp_vals["skf"] = sklearn.model_selection.StratifiedKFold(
                     n_splits=num_cv_folds,
@@ -237,10 +233,10 @@ class MFELandmarking:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Numerical fitted data.
 
         y : :obj:`np.ndarray`
-            Target attribute from fitted data.
+            Target attribute.
 
         lm_sample_frac : float, optional
             Proportion of instances to be sampled before extracting the
@@ -252,9 +248,8 @@ class MFELandmarking:
             is taken into account. Argument used to exploit precomputations.
 
         random_state : int, optional
-            If int, random_state is the seed used by the random number
-            generator; If None, the random number generator is the
-            RandomState instance used by np.random.
+            If given, set the random seed before any pseudo-random calculations
+            to keep the experiments reproducible.
 
         Returns
         -------
@@ -293,10 +288,10 @@ class MFELandmarking:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Numerical fitted data.
 
         y : :obj:`np.ndarray`
-            Target attribute from fitted data.
+            Target attribute.
 
         score : :obj:`callable`
             Function to compute score of the K-fold evaluations. Possible
@@ -307,8 +302,8 @@ class MFELandmarking:
             split data in train/test sets.
 
         num_cv_folds : int, optional
-            Number of num_cv_folds to k-fold cross validation. Used only if
-            ``skf`` is None.
+            Number of folds to k-fold cross validation. Used only if ``skf``
+            is None.
 
         shuffle_cv_folds : bool, optional
             If True, shuffle the data before splitting into the k-fold cross
@@ -325,14 +320,13 @@ class MFELandmarking:
             is taken into account. Argument used to exploit precomputations.
 
         random_state : int, optional
-            If int, random_state is the seed used by the random number
-            generator; If None, the random number generator is the
-            RandomState instance used by np.random.
+            If given, set the random seed before any pseudo-random calculations
+            to keep the experiments reproducible.
 
         Returns
         -------
         :obj:`np.ndarray`
-            The performance of each fold.
+            The Decision Tree best-node model performance of each fold.
 
         References
         ----------
@@ -392,10 +386,10 @@ class MFELandmarking:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Numerical fitted data.
 
         y : :obj:`np.ndarray`
-            Target attribute from fitted data.
+            Target attribute.
 
         score : :obj:`callable`
             Function to compute score of the K-fold evaluations. Possible
@@ -405,16 +399,16 @@ class MFELandmarking:
             Stratified K-Folds cross-validator. Provides train/test indices to
             split data in train/test sets.
 
-        num_cv_folds : :obj:`int`, optional
-            Number of num_cv_folds to k-fold cross validation. Used only if
-            ``skf`` is None.
+        num_cv_folds : int, optional
+            Number of folds to k-fold cross validation. Used only if ``skf``
+            is None.
 
         shuffle_cv_folds : :obj:`bool`, optional
             If True, shuffle the data before splitting into the k-fold cross
             validation folds. The random seed used for this process is the
             ``random_state`` argument.
 
-        lm_sample_frac : :obj:`float`, optional
+        lm_sample_frac : float, optional
             Proportion of instances to be sampled before extracting the
             metafeature. Used only if ``sample_inds`` is None.
 
@@ -423,15 +417,14 @@ class MFELandmarking:
             extracting this metafeature. If None, then ``lm_sample_frac``
             is taken into account. Argument used to exploit precomputations.
 
-        random_state : :obj:`int`, optional
-            If int, random_state is the seed used by the random number
-            generator; If None, the random number generator is the
-            RandomState instance used by np.random.
+        random_state : int, optional
+            If given, set the random seed before any pseudo-random calculations
+            to keep the experiments reproducible.
 
         Returns
         -------
         :obj:`np.ndarray`
-            The performance of each fold.
+            The Decision Tree random-node model performance of each fold.
 
         References
         ----------
@@ -498,12 +491,12 @@ class MFELandmarking:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Numerical fitted data.
 
         y : :obj:`np.ndarray`
-            Target attribute from fitted data.
+            Target attribute.
 
-        score : obj:`callable`
+        score : :obj:`callable`
             Function to compute score of the K-fold evaluations. Possible
             functions are described in `scoring.py` module.
 
@@ -512,7 +505,7 @@ class MFELandmarking:
             split data in train/test sets.
 
         num_cv_folds : int, optional
-            Number of num_cv_folds to k-fold cross validation. Used only if
+            Number of folds to k-fold cross validation. Used only if
             ``skf`` is None.
 
         shuffle_cv_folds : bool, optional
@@ -530,9 +523,8 @@ class MFELandmarking:
             is taken into account. Argument used to exploit precomputations.
 
         random_state : int, optional
-            If int, random_state is the seed used by the random number
-            generator; If None, the random number generator is the
-            RandomState instance used by np.random.
+            If given, set the random seed before any pseudo-random calculations
+            to keep the experiments reproducible.
 
         cv_folds_imp_rank : :obj:`np.ndarray`, optional
             Ranking based on the predictive attribute importance per
@@ -545,7 +537,7 @@ class MFELandmarking:
         Returns
         -------
         :obj:`np.ndarray`
-            The performance of each fold.
+            The Decision Tree worst-node model performance of each fold.
 
         References
         ----------
@@ -617,10 +609,10 @@ class MFELandmarking:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Numerical fitted data.
 
         y : :obj:`np.ndarray`
-            Target attribute from fitted data.
+            Target attribute.
 
         score : :obj:`callable`
             Function to compute score of the K-fold evaluations. Possible
@@ -649,14 +641,13 @@ class MFELandmarking:
             is taken into account. Argument used to exploit precomputations.
 
         random_state : int, optional
-            If int, random_state is the seed used by the random number
-            generator; If None, the random number generator is the
-            RandomState instance used by np.random.
+            If given, set the random seed before any pseudo-random calculations
+            to keep the experiments reproducible.
 
         Returns
         -------
         :obj:`np.ndarray`
-            The performance of each fold.
+            The Linear Discriminant Analysis model performance of each fold.
 
         References
         ----------
@@ -718,10 +709,10 @@ class MFELandmarking:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Numerical fitted data.
 
         y : :obj:`np.ndarray`
-            Target attribute from fitted data.
+            Target attribute.
 
         score : :obj:`callable`
             Function to compute score of the K-fold evaluations. Possible
@@ -750,14 +741,13 @@ class MFELandmarking:
             is taken into account. Argument used to exploit precomputations.
 
         random_state : int, optional
-            If int, random_state is the seed used by the random number
-            generator; If None, the random number generator is the
-            RandomState instance used by np.random.
+            If given, set the random seed before any pseudo-random calculations
+            to keep the experiments reproducible.
 
         Returns
         -------
         :obj:`np.ndarray`
-            The performance of each fold.
+            The Naive Bayes model performance of each fold.
 
         References
         ----------
@@ -819,10 +809,10 @@ class MFELandmarking:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Numerical fitted data.
 
         y : :obj:`np.ndarray`
-            Target attribute from fitted data.
+            Target attribute.
 
         score : :obj:`callable`
             Function to compute score of the K-fold evaluations. Possible
@@ -851,14 +841,13 @@ class MFELandmarking:
             is taken into account. Argument used to exploit precomputations.
 
         random_state : int, optional
-            If int, random_state is the seed used by the random number
-            generator; If None, the random number generator is the
-            RandomState instance used by np.random.
+            If given, set the random seed before any pseudo-random calculations
+            to keep the experiments reproducible.
 
         Returns
         -------
         :obj:`np.ndarray`
-            The performance of each fold.
+            The 1-NN model performance of each fold.
 
         References
         ----------
@@ -917,16 +906,18 @@ class MFELandmarking:
         """Performance of Elite Nearest Neighbor.
 
         Elite nearest neighbor uses the most informative attribute in the
-        dataset to induce the 1-nearest neighbor. With the subset of informati-
-        ve attributes is expected that the models should be noise tolerant.
+        dataset to induce the 1-nearest neighbor.
+
+        With the subset of informative attributes it is expected that the
+        models should be noise tolerant.
 
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Numerical fitted data.
 
         y : :obj:`np.ndarray`
-            Target attribute from fitted data.
+            Target attribute.
 
         score : :obj:`callable`
             Function to compute score of the K-fold evaluations. Possible
@@ -937,7 +928,7 @@ class MFELandmarking:
             split data in train/test sets.
 
         num_cv_folds : int, optional
-            Number of num_cv_folds to k-fold cross validation. Used only if
+            Number of folds to k-fold cross validation. Used only if
             ``skf`` is None.
 
         shuffle_cv_folds : bool, optional
@@ -955,9 +946,8 @@ class MFELandmarking:
             is taken into account. Argument used to exploit precomputations.
 
         random_state : int, optional
-            If int, random_state is the seed used by the random number
-            generator; If None, the random number generator is the
-            RandomState instance used by np.random.
+            If given, set the random seed before any pseudo-random calculations
+            to keep the experiments reproducible.
 
         cv_folds_imp_rank : :obj:`np.ndarray`, optional
             Ranking based on the predictive attribute importance per
@@ -970,7 +960,7 @@ class MFELandmarking:
         Returns
         -------
         :obj:`np.ndarray`
-            The performance of each fold.
+            The Elite 1-NN model performance of each fold.
 
         References
         ----------

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -323,14 +323,14 @@ class MFE:
         self.hypparam_model_dt = (hypparam_model_dt.copy()
                                   if hypparam_model_dt else None)
 
+        # """Total time elapsed for precomputations."""
         self.time_precomp = -1.0
-        """Total time elapsed for precomputations."""
 
+        # """Total time elapsed for metafeature extraction."""
         self.time_extract = -1.0
-        """Total time elapsed for metafeature extraction."""
 
+        # """Total time elapsed in total (precomp + extract.)"""
         self.time_total = -1.0
-        """Total time elapsed in total (precomp + extract.)"""
 
     def _call_summary_methods(
             self,
@@ -1383,7 +1383,7 @@ class MFE:
         if include_references:
             aux = docstring.split("References\n        ----------\n")
             if len(aux) >= 2:
-                split = aux[1].split(f".. [")
+                split = aux[1].split(".. [")
                 if len(split) >= 2:
                     del split[0]
                     for spl in split:

--- a/pymfe/model_based.py
+++ b/pymfe/model_based.py
@@ -33,9 +33,9 @@ class MFEModelBased:
        argument, without any previous verification of argument value or its
        type, via kwargs argument of ``extract`` method of MFE class.
 
-     4. The return value of all feature extraction methods should be a single
-        value or a generic Sequence (preferably a :obj:`np.ndarray`)
-        type with numeric values.
+    4. The return value of all feature extraction methods should be a single
+       value or a generic Sequence (preferably a :obj:`np.ndarray`)
+       type with numeric values.
 
     There is another type of method adopted for automatic detection. It is
     adopted the prefix ``precompute_`` for automatic detection of these
@@ -180,13 +180,16 @@ class MFEModelBased:
         :obj:`np.ndarray`
             DT model properties table calculated with ``extract_table`` method.
             Check its documentation for more information.
-                - Each line represents a node.
-                - Column 0: It is the id of the attribute splitted in that
-                  node.
-                - Columns 1: It is the number of examples that fall on that
-                  node.
-                - Columns 2: It is 0 if the node is not a leaf, otherwise is
-                  the class number represented by that leaf node.
+
+        Notes
+        -----
+            Each line in the returned array represents a node where:
+              - Column 0: It is the id of the attribute splitted in that
+                node.
+              - Columns 1: It is the number of examples that fall on that
+                node.
+              - Columns 2: It is 0 if the node is not a leaf, otherwise is
+                the class number represented by that leaf node.
         """
         if leaf_nodes is None:
             leaf_nodes = cls._get_leaf_node_array(dt_model)

--- a/pymfe/relative.py
+++ b/pymfe/relative.py
@@ -63,28 +63,28 @@ class MFERelativeLandmarking:
 
         Parameters
         ----------
-        mtf_names : :obj:`str`
+        mtf_names : str
             Name of each generated metafeature (after extraction and
             summarization).
 
-        mtf_vals : :obj:`str`
+        mtf_vals : str
             Value of each generated metafeature (after extraction and
             summarization).
 
-        mtf_time : :obj:`str`
+        mtf_time : str
             Time elapsed to generate each metafeature (after extraction
             and summarization).
 
-        class_indexes : :obj:`List` of :obj:`int`
+        class_indexes : :obj:`list` of int
             List of indexes corresponding to metafeatures associated to
             metafeature groups present in this postprocessing method name
             (``Landmarking`` and ``Relative``.)
 
-        groups : :obj:`Tuple` of :obj:`str`
+        groups : :obj:`tuple` of str
             User-selected and automatic inserted (due to group dependencies)
             groups of metafeatures.
 
-        inserted_group_dep : :obj:`Tuple` of :obj:`str`
+        inserted_group_dep : :obj:`tuple` of str
             Tuple with all automatic inserted metafeature groups due to
             dependency between groups.
 

--- a/pymfe/statistical.py
+++ b/pymfe/statistical.py
@@ -65,7 +65,7 @@ class MFEStatistical:
 
         Parameters
         ----------
-        y : :obj:`np.ndarray`, optional
+        y : :obj:`np.ndarray`
             The target attribute from fitted data.
 
         kwargs:
@@ -102,10 +102,10 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`, optional
-            Numerical attributes from fitted data.
+            Numerical fitted data.
 
-        y : :obj:`np.ndarray`, optional
-            Target attribute from fitted data.
+        y : :obj:`np.ndarray`
+            Target attribute.
 
         kwargs:
             Additional arguments. May have previously precomputed before this
@@ -145,7 +145,7 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`, optional
-            Numerical attributes from fitted data.
+            Numerical fitted data.
 
         ddof : int, optional
             Degrees of freedom of covariance matrix.
@@ -260,12 +260,12 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
-        y : :obj:`np.ndarray`, optional
-            Target attribute from fitted data.
+        y : :obj:`np.ndarray`
+            Target attribute.
 
-        can_cors: :obj:`np.ndarray`, optional
+        can_cors : :obj:`np.ndarray`, optional
             Canonical correlations between ``N`` and the one-hot encoded
             version of ``y``. Argument used to take advantage of
             precomputations.
@@ -305,12 +305,12 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
-        y : :obj:`np.ndarray`, optional
-            Target attribute from fitted data.
+        y : :obj:`np.ndarray`
+            Target attribute.
 
-        norm_ord : :obj:`numeric`
+        norm_ord : :obj:`numeric`, optional
             Minkowski Distance parameter. Minkowski Distance has the following
             popular cases for this argument value
 
@@ -342,7 +342,7 @@ class MFEStatistical:
 
         Returns
         -------
-        :obj:`float`
+        float
             Gravity of the numeric dataset.
 
         Raises
@@ -393,7 +393,7 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
         abs_corr_mat : :obj:`np.ndarray`, optional
             Absolute correlation matrix of ``N``. Argument used to exploit
@@ -440,9 +440,9 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
-        ddof : :obj:`int`, optional
+        ddof : int, optional
             Degrees of freedom for covariance matrix.
 
         cov_mat : :obj:`np.ndarray`, optional
@@ -492,10 +492,10 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
-        y : :obj:`np.ndarray`, optional
-            Target attribute from fitted data.
+        y : :obj:`np.ndarray`
+            Target attribute.
 
         can_cors : :obj:`np.ndarray`, optional
             Canonical correlations between ``N`` and the one-hot encoded
@@ -504,7 +504,7 @@ class MFEStatistical:
 
         Returns
         -------
-        :obj:`int` | :obj:`float`
+        int | float
             Number of canonical correlations between each attribute and
             class, if ``ft_can_cor`` is executed successfully. Returns
             :obj:`np.nan` otherwise.
@@ -531,9 +531,9 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
-        ddof : :obj:`int`, optional
+        ddof : int, optional
             Degrees of freedom for covariance matrix.
 
         cov_mat : :obj:`np.ndarray`, optional
@@ -572,13 +572,13 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
-        allow_zeros : :obj:`bool`
+        allow_zeros : :obj:`bool`, optional
             If True, then the geometric mean of all attributes with zero values
             is set to zero. Otherwise, is set to :obj:`np.nan` these values.
 
-        epsilon : :obj:`float`
+        epsilon : float, optional
             A small value which all values with absolute value lesser than it
             is considered zero-valued. Used only if ``allow_zeros`` is False.
 
@@ -623,9 +623,9 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
-        epsilon : :obj:`float`, optional
+        epsilon : float, optional
             A tiny value to prevent division by zero.
 
         Returns
@@ -652,7 +652,7 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
         Returns
         -------
@@ -675,7 +675,7 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
         method : int, optional
             Defines the strategy used for estimate data kurtosis. Used for
@@ -685,24 +685,24 @@ class MFEStatistical:
             +--------+-----------------------------------------------+
             |Option  | Formula                                       |
             +--------+-----------------------------------------------+
-            |1       | Kurt_1 = m_4 / m_2**2 - 3                     |
-            |        | (default of ``scipy.stats``)                  |
+            |1       | Kurt_1 = (m_4 / m_2**2 - 3)                   |
+            |        | (default of `scipy.stats` package)            |
             +--------+-----------------------------------------------+
-            |2       | Kurt_2 = ((n+1) * Kurt_1 + 6) * (n-1) / f_2   |
+            |2       | Kurt_2 = (((n+1) * Kurt_1 + 6) * (n-1) / f_2),|
             |        | f_2 = ((n-2)*(n-3))                           |
             +--------+-----------------------------------------------+
-            |3       | Kurt_3 = m_4 / s**4 - 3                       |
-            |        |        = (Kurt_1+3) * (1 - 1/n)**2 - 3        |
+            |3       | Kurt_3 = (m_4 / s**4 - 3)                     |
+            |        |        = ((Kurt_1+3) * (1 - 1/n)**2 - 3)      |
             +--------+-----------------------------------------------+
 
-            Where ``n`` is the number of elements in ``values``, ``s`` is
-            the standard deviation of ``values`` and ``m_i`` is the ith
-            statistical momentum of ``values``.
+            Where `n` is the number of instances in ``N``, `s` is the standard
+            deviation of each attribute in ``N``, and `m_i` is the ith
+            statistical momentum of each attribute in ``N``.
 
             Note that if the selected method is unable to be calculated due
             to division by zero, then the first method is used instead.
 
-        bias : bool
+        bias : bool, optional
             If False, then the calculations are corrected for statistical bias.
 
         Returns
@@ -732,9 +732,9 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
-        factor : :obj:`float`
+        factor : float, optional
             Multiplication factor for output correction. The default ``factor``
             is 1.4826 since it is an approximated result of MAD of a normally
             distributed data (with any mean and standard deviation of 1.0), so
@@ -760,7 +760,7 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
         Returns
         -------
@@ -783,7 +783,7 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
         Returns
         -------
@@ -806,7 +806,7 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
         Returns
         -------
@@ -829,7 +829,7 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
         Returns
         -------
@@ -861,7 +861,7 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
         threshold : float, optional
             A value of the threshold, where correlation is assumed to be strong
@@ -869,7 +869,7 @@ class MFEStatistical:
 
         normalize : bool, optional
             If True, the result is normalized by a factor of 2/(d*(d-1)), where
-            ``d`` is number of attributes (columns) in ``N``.
+            `d` is number of attributes (columns) in ``N``.
 
         abs_corr_mat : :obj:`np.ndarray`, optional
             Absolute correlation matrix of ``N``. Argument used to exploit
@@ -877,7 +877,7 @@ class MFEStatistical:
 
         Returns
         -------
-        :obj:`int` | :obj:`float`
+        int | float
             If ``normalize`` is False, this method returns the number of
             highly correlated pair of distinct attributes. Otherwise,
             return the proportion of highly correlated attributes.
@@ -912,24 +912,24 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
         method : str, optional
             Select the normality test to be executed. This argument must assume
             one of the options shown below:
 
-            - shapiro-wilk: directly from `shapiro`_: the Shapiro-Wilk
-              test tests the null hypothesis that the data was drawn from a
-              normal distribution.
+            - shapiro-wilk: from `scipy.stats.shapiro` documentation: the
+              Shapiro-Wilk test tests the null hypothesis that the data was
+              drawn from a normal distribution.
 
-            - dagostino-pearson: directly from `normaltest`_: It is based
-              on D'Agostino and Pearson's, test that combines skew and kurtosis
-              to produce an omnibus test of normality.
+            - dagostino-pearson: from `scipy.stats.normaltest` documentation:
+              It is based on D'Agostino and Pearson's, test that combines skew
+              and kurtosis to produce an omnibus test of normality.
 
-            - anderson-darling: directly from `anderson`_: The
-              Ander-son-Darling tests the null hypothesis that a sample is
+            - anderson-darling: from `scipy.stats.anderson` documentation: The
+              Anderson-Darling tests the null hypothesis that a sample is
               drawn from a population that follows a particular distribution.
-              In this method context, that ``particular distribution`` is fixed
+              In this method context, that `particular distribution` is fixed
               in the normal/gaussian.
 
             - all: perform all tests cited above. To consider an attribute
@@ -941,14 +941,14 @@ class MFEStatistical:
             normality tests.
 
         failure : str, optional
-            Used only if ``method`` argument value is ``all``. This argument
-            must assumed one value between ``soft`` or ``hard``. If ``soft``,
-            then if a single test can`t have its null hypothesis
-            (of the normal/Gaussian distribution of the attribute data)
-            rejected for some attribute, then that attribute is considered
-            normally distributed. If ``hard``, then is necessary the rejection
-            of the null hypothesis of every single normality test to consider
-            the attribute normally distributed.
+            Used only if ``method`` argument value is `all`. This argument
+            must assumed one value between `soft` or `hard`. If `soft`, then if
+            a single test have its null hypothesis (which all states the data
+            follows a Guassian distribution) rejected for some attribute, then
+            that attribute is already considered normally distributed. If value
+            is `hard`, then is necessary the rejection of the null hypothesis
+            of every single normality test to consider the attribute normally
+            distributed.
 
         max_samples : int, optional
             Max samples used while performing the normality tests.
@@ -960,7 +960,7 @@ class MFEStatistical:
 
         Returns
         -------
-        :obj:`int`
+        int
             The number of normally distributed attributes based on the
             ``method``. If ``max_samples`` is non-positive, :obj:`np.nan`
             is returned instead.
@@ -969,12 +969,6 @@ class MFEStatistical:
         ------
         ValueError
             If ``method`` or ``failure`` is not a valid option.
-
-        Notes
-        -----
-            .. _shapiro: :obj:`scipy.stats.shapiro` documentation.
-            .. _normaltest: :obj:`scipy.stats.normaltest` documentation.
-            .. _anderson: :obj:`scipy.stats.anderson` documentation.
 
         References
         ----------
@@ -1052,14 +1046,14 @@ class MFEStatistical:
         An attribute has outlier if some value is outside the closed interval
         [first_quartile - WHIS * IQR, third_quartile + WHIS * IQR], where IQR
         is the Interquartile Range (third_quartile - first_quartile), and WHIS
-        value is typically ``1.5``.
+        value is typically `1.5`.
 
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
-        whis : float
+        whis : float, optional
             A factor to multiply IQR and set up non-outlier interval
             (as stated above). Higher values make the interval more
             significant, thus increasing the tolerance against outliers, where
@@ -1068,7 +1062,7 @@ class MFEStatistical:
 
         Returns
         -------
-        :obj:`int`
+        int
             Number of attributes with at least one outlier.
 
         References
@@ -1098,7 +1092,7 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
         Returns
         -------
@@ -1120,9 +1114,9 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
-        ddof : float
+        ddof : float, optional
             Degrees of freedom for standard deviation.
 
         Returns
@@ -1157,10 +1151,10 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
-        y : :obj:`np.ndarray`, optional
-            Target attribute from fitted data.
+        y : :obj:`np.ndarray`
+            Target attribute.
 
         ddof : int, optional
             Degrees of freedom for covariance matrix, calculated during this
@@ -1177,7 +1171,7 @@ class MFEStatistical:
 
         Returns
         -------
-        :obj:`float`
+        float
             Homogeneity of covariances test result.
 
         Notes
@@ -1274,11 +1268,11 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
-        method : :obj:`int`, optional
+        method : int, optional
             Defines the strategy used for estimate data skewness. This argument
-            is used fo compatibility with R package ``e1071``. The options must
+            is used fo compatibility with R package `e1071`. The options must
             be one of the following:
 
             +--------+-----------------------------------------------+
@@ -1292,9 +1286,9 @@ class MFEStatistical:
             |3       | Skew_3 = m_3 / s**3 = Skew_1 ((n-1)/n)**(3/2) |
             +--------+-----------------------------------------------+
 
-            Where ``n`` is the number of elements in dataset, ``m_i`` is the
-            ith momentum of the attribute, and ``s`` is the standard deviation
-            of the attribute.
+            Where `n` is the number of instances in ``N``, `s` is the standard
+            deviation of each attribute in ``N``, and `m_i` is the ith
+            statistical momentum of each attribute in ``N``.
 
             Note that if the selected method is unable to be calculated due to
             division by zero, then the first method will be used instead.
@@ -1326,22 +1320,22 @@ class MFEStatistical:
     def ft_sparsity(cls, X: np.ndarray, normalize: bool = True) -> np.ndarray:
         """Compute (possibly normalized) sparsity metric for each attribute.
 
-        Sparsity ``S`` of a vector ``v`` of numeric values is defined as
+        Sparsity `S` of a vector `v` of numeric values is defined as
 
             S(v) = (1.0 / (n - 1.0)) * ((n / phi(v)) - 1.0),
 
         where
-            - ``n`` is the number of instances in dataset ``X``.
-            - ``phi(v)`` is the number of distinct values in ``v``.
+            - `n` is the number of instances in dataset ``X``.
+            - `phi(v)` is the number of distinct values in `v`.
 
         Parameters
         ----------
         X : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
         normalize : bool, optional
             If True, then the output will be S(v) as shown above. Otherwise,
-            the output is not be multiplied by the ``(1.0 / (n - 1.0))`` factor
+            the output is not be multiplied by the `(1.0 / (n - 1.0))` factor
             (i.e. new output is defined as S'(v) = ((n / phi(v)) - 1.0)).
 
         Returns
@@ -1372,10 +1366,10 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
-        pcut : float
-            Percentage of cut from both the ``lower`` and ``higher`` values.
+        pcut : float, optional
+            Percentage of cut from both the `lower` and `higher` values.
             This value should be in interval [0.0, 0.5), where if 0.0 the
             return value is the default mean calculation. If this argument is
             not in mentioned interval, then the return value is :obj:`np.nan`
@@ -1405,9 +1399,9 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
-        ddof : float
+        ddof : float, optional
             Degrees of freedom for variance.
 
         Returns
@@ -1438,11 +1432,11 @@ class MFEStatistical:
 
             L = prod(1.0 / (1.0 + can_cor_eig_i))
 
-        Where ``can_cor_eig_i`` is the ith eigenvalue related to the ith
-        canonical correlation ``can_cor_i`` between the attributes in ``N``
+        Where `can_cor_eig_i` is the ith eigenvalue related to the ith
+        canonical correlation `can_cor_i` between the attributes in ``N``
         and the binarized (one-hot encoded) version of ``y``.
 
-        The relationship between ``can_cor_eig_i`` and ``can_cor_i`` is
+        The relationship between `can_cor_eig_i` and `can_cor_i` is
         given by:
 
             can_cor_i = sqrt(can_cor_eig_i / (1 + can_cor_eig_i))
@@ -1454,16 +1448,16 @@ class MFEStatistical:
         Parameters
         ----------
         N : :obj:`np.ndarray`
-            Attributes from fitted data.
+            Fitted numerical data.
 
-        y : :obj:`np.ndarray`, optional
-            Target attribute from fitted data.
+        y : :obj:`np.ndarray`
+            Target attribute.
 
         can_cor_eigvals : :obj:`np.ndarray`, optional
             Eigenvalues associated with the canonical correlations of
             ``N`` and one-hot encoded ``y``. This argument is used to
             exploit precomputations. The relationship between the ith
-            canonical correlation ``can_cor_i`` and its eigenvalue is:
+            canonical correlation `can_cor_i` and its eigenvalue is:
 
                 can_cor_i = sqrt(can_cor_eigval_i / (1 + can_cor_eigval_i))
 
@@ -1478,7 +1472,7 @@ class MFEStatistical:
 
         Returns
         -------
-        :obj:`float`
+        float
             Wilk's lambda value.
 
         References

--- a/pymfe/statistical.py
+++ b/pymfe/statistical.py
@@ -504,7 +504,7 @@ class MFEStatistical:
 
         Returns
         -------
-        int | float
+        int or float
             Number of canonical correlations between each attribute and
             class, if ``ft_can_cor`` is executed successfully. Returns
             :obj:`np.nan` otherwise.

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,7 @@
 sphinx
-sphinx-gallery
 sphinx_rtd_theme
+pillow
+seaborn
+sphinx-gallery
 numpydoc
 liac-arff

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 scipy
-sklearn
+scikit-learn
 patsy
 pandas
 statsmodels

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -3,6 +3,7 @@ import pytest
 import typing as t
 
 import numpy as np
+import sklearn.tree
 
 from pymfe import _internal
 from pymfe.mfe import MFE
@@ -296,6 +297,51 @@ class TestArchitecture:
 
         assert mfe._custom_args_ft["N"].shape[1] == exp_value
 
+    def test_extract_from_model(self):
+        X, y = utils.load_xy(2)
+
+        model = sklearn.tree.DecisionTreeClassifier(random_state=1234).fit(
+            X.values, y.values)
+
+        mtf_name, mtf_vals = MFE(random_state=1234).extract_from_model(model)
+
+        extractor = MFE(groups="model-based", random_state=1234)
+        extractor.fit(X=X.values, y=y.values, transform_num=False)
+        mtf_name2, mtf_vals2 = extractor.extract()
+
+        assert (np.all(mtf_name == mtf_name2)
+                and np.allclose(mtf_vals, mtf_vals2))
+
+    def test_extract_from_model_invalid1(self):
+        X, y = utils.load_xy(2)
+
+        model = sklearn.tree.DecisionTreeRegressor().fit(X.values, y.values)
+
+        with pytest.raises(TypeError):
+            MFE().extract_from_model(model)
+
+    def test_extract_from_model_invalid2(self):
+        X, y = utils.load_xy(2)
+
+        model = sklearn.tree.DecisionTreeClassifier(random_state=1234).fit(
+            X.values, y.values)
+
+        with pytest.raises(KeyError):
+            MFE().extract_from_model(model, arguments_fit={"dt_model": model})
+
+    def test_extract_from_model_invalid3(self):
+        model = sklearn.tree.DecisionTreeClassifier()
+
+        with pytest.raises(RuntimeError):
+            MFE().extract_from_model(model)
+
+    def test_extract_from_model_invalid4(self):
+        X, y = utils.load_xy(2)
+
+        model = sklearn.tree.DecisionTreeClassifier().fit(X, y)
+
+        with pytest.raises(ValueError):
+            MFE(groups="general").extract_from_model(model)
 
 class TestArchitectureWarnings:
     def test_feature_warning1(self):

--- a/tests/test_model_based.py
+++ b/tests/test_model_based.py
@@ -243,6 +243,13 @@ class TestModelBased:
 
         mfe.fit(X.values, y.values, precomp_groups=precomp_group)
 
+        if precomp_group is None:
+            # Note: the precomputation of 'model-based' group is always
+            # forced due to the need of the 'dt_model' value
+            mfe._precomp_args_ft = {
+                "dt_model": mfe._precomp_args_ft.get("dt_model")
+            }
+
         value = mfe.extract()[1]
 
         if exp_value is np.nan:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,5 +1,6 @@
 """Test module for MFE class output details."""
 import pytest
+import sklearn.tree
 
 import pymfe._internal as _internal
 from pymfe.mfe import MFE
@@ -76,7 +77,7 @@ class TestOutput:
 
         captured = capsys.readouterr().out
 
-        assert (not msg_expected) or captured
+        assert ((not msg_expected) and (not captured)) or (msg_expected and captured)
 
     def test_verbosity_2(self, capsys):
         X, y = load_xy(0)
@@ -99,4 +100,19 @@ class TestOutput:
 
         captured = capsys.readouterr().out
 
-        assert (not msg_expected) or captured
+        assert ((not msg_expected) and (not captured)) or (msg_expected and captured)
+
+    @pytest.mark.parametrize("verbosity, msg_expected", [
+        (0, False),
+        (1, True),
+    ])
+    def test_verbosity_from_model(self, verbosity, msg_expected, capsys):
+        X, y = load_xy(2)
+
+        model = sklearn.tree.DecisionTreeClassifier().fit(X.values, y.values)
+
+        MFE().extract_from_model(model, verbose=verbosity)
+
+        captured = capsys.readouterr().out
+
+        assert ((not msg_expected) and (not captured)) or (msg_expected and captured)


### PR DESCRIPTION
## Major changes
- Adjustments in some pydocs to keep a more consistent pattern, and also some pydoc fixes.
- Reformatted 'model-based' group metafeature extraction methods arguments to a consistent format (all model-based metafeatures now receive a single mandatory argument 'dt_model', and all other arguments are optional arguments from precomputations.) Now it is much easier to use those methods directly without the main class (mfe) filter, if desired.
- Now accepting user custom arguments in precomputation methods.
- Added 'extract_from_model' MFE method, making easy to extract model-based metafeatures from a pre-fitted model without using the training data.

## Minor changes
- Added unsupervised example in 'README.md'
- Changed from 'sklearn' to 'scikit-learn' in 'requirements.txt'