### PR TITLE
Metafeature extraction with confidence intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,20 @@ ft = mfe.extract(
 print(ft)
 ```
 
+You can also extract your metafeatures with confidence intervals using boostrap. Keep in mind that this method extracts each metafeature several times, and may be very expensive depending mainly on your data and the number of metafeature extract methods called.
+
+```python
+# Extract metafeatures with confidence interval
+mfe = MFE(features=["mean", "nr_cor_attr", "sd", "max"])
+mfe.fit(X, y)
+ft = mfe.extract_with_confidence(
+    sample_num=256,
+    confidence=0.99,
+    verbose=1,
+)
+print(ft)
+```
+
 ## Documentation
 We write a great Documentation to guide you on how to use the pymfe library. You can find the Documentation in this [link](https://pymfe.readthedocs.io/en/latest/?badge=latest).
 You can find in the documentation interesting pages like:

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ ft = mfe.extract(
 print(ft)
 ```
 
-You can also extract your metafeatures with confidence intervals using boostrap. Keep in mind that this method extracts each metafeature several times, and may be very expensive depending mainly on your data and the number of metafeature extract methods called.
+You can also extract your metafeatures with confidence intervals using bootstrap. Keep in mind that this method extracts each metafeature several times, and may be very expensive depending mainly on your data and the number of metafeature extract methods called.
 
 ```python
 # Extract metafeatures with confidence interval

--- a/pymfe/clustering.py
+++ b/pymfe/clustering.py
@@ -373,14 +373,14 @@ class MFEClustering:
 
             cls_inds = _utils.calc_cls_inds(y=y, classes=classes)
 
-        interclass_dists = np.array([
+        interclass_dists = [
             cls._calc_normalized_interclass_dist(
                 N[cls_inds[id_cls_a, :], :],
                 N[cls_inds[id_cls_b, :], :],
                 dist_metric=dist_metric)
             for id_cls_a, id_cls_b in itertools.combinations(
                 np.arange(cls_inds.shape[0]), 2)
-        ])
+        ]
 
         return interclass_dists
 

--- a/pymfe/clustering.py
+++ b/pymfe/clustering.py
@@ -585,7 +585,12 @@ class MFEClustering:
                 classes=classes,
                 cls_inds=cls_inds).max()
 
-        vdu = pairwise_norm_interclass_dist.min() / intraclass_dists.max()
+        _min_interclass_dist = np.inf
+
+        for vals in pairwise_norm_interclass_dist:
+            _min_interclass_dist = min(_min_interclass_dist, np.min(vals))
+
+        vdu = _min_interclass_dist / intraclass_dists.max()
 
         return vdu
 
@@ -693,7 +698,12 @@ class MFEClustering:
 
         norm_factor = 2.0 / (class_num * (class_num - 1.0))
 
-        return pairwise_norm_interclass_dist.sum() * norm_factor
+        _sum_interclass_dist = 0.0
+
+        for vals in pairwise_norm_interclass_dist:
+            _sum_interclass_dist += np.sum(vals)
+
+        return _sum_interclass_dist * norm_factor
 
     @classmethod
     def ft_sil(cls,

--- a/pymfe/complexity.py
+++ b/pymfe/complexity.py
@@ -275,7 +275,7 @@ class MFEComplexity:
         # The measure is computed in the literature using the mean. However, it
         # is formulated here as a meta-feature. Therefore, the post-processing
         # should be used to get the mean and other measures as well.
-        return np.asarray(f3)
+        return f3
 
     @classmethod
     def ft_f4(
@@ -332,12 +332,12 @@ class MFEComplexity:
         f4 = np.zeros(ovo_comb.shape[0], dtype=float)
 
         for ind, (cls_id_1, cls_id_2) in enumerate(ovo_comb):
-            cls_subset_intersec = np.logical_or(cls_inds[cls_id_1, :],
-                                                cls_inds[cls_id_2, :])
+            cls_subset_union = np.logical_or(cls_inds[cls_id_1, :],
+                                             cls_inds[cls_id_2, :])
 
-            cls_1 = cls_inds[cls_id_1, cls_subset_intersec]
-            cls_2 = cls_inds[cls_id_2, cls_subset_intersec]
-            N_subset = N[cls_subset_intersec, :]
+            cls_1 = cls_inds[cls_id_1, cls_subset_union]
+            cls_2 = cls_inds[cls_id_2, cls_subset_union]
+            N_subset = N[cls_subset_union, :]
 
             while N_subset.size > 0:
                 # True if the example is in the overlapping region
@@ -351,13 +351,25 @@ class MFEComplexity:
                 # region
                 overlapped_region = feat_overlapped_region[:, ind_less_overlap]
 
-                # removing the non overlapped features
+                # removing the non-overlapping instances
                 N_subset = N_subset[overlapped_region, :]
                 cls_1 = cls_1[overlapped_region]
                 cls_2 = cls_2[overlapped_region]
 
-                # removing the most efficient feature
-                N_subset = np.delete(N_subset, ind_less_overlap, axis=1)
+                inst_num_1 = np.sum(cls_1)
+                inst_num_2 = np.sum(cls_2)
+
+                if inst_num_1 == 0 or inst_num_2 == 0:
+                    # All instances are already discriminated, thus the
+                    # procecure may stop, and the results must be 0 (by
+                    # definition of F4 measure, which is the ratio of
+                    # examples not discriminated after applying its
+                    # algorithm multiple times.)
+                    N_subset = np.array([])
+
+                else:
+                    # removing the most efficient feature
+                    N_subset = np.delete(N_subset, ind_less_overlap, axis=1)
 
             subset_size = N_subset.shape[0]
 
@@ -367,7 +379,7 @@ class MFEComplexity:
         # The measure is computed in the literature using the mean. However, it
         # is formulated here as a meta-feature. Therefore, the post-processing
         # should be used to get the mean and other measures as well.
-        return np.asarray(f4)
+        return f4
 
     @classmethod
     def ft_l2(cls,

--- a/pymfe/complexity.py
+++ b/pymfe/complexity.py
@@ -57,7 +57,6 @@ class MFEComplexity:
     computed in module ``statistical`` can freely be used for any
     precomputation or feature extraction method of module ``landmarking``).
     """
-
     @classmethod
     def precompute_fx(cls, y: t.Optional[np.ndarray] = None,
                       **kwargs) -> t.Dict[str, t.Any]:
@@ -170,25 +169,39 @@ class MFEComplexity:
         return np.asarray(list(ovo_comb), dtype=int)
 
     @staticmethod
-    def _calc_minmax(N: np.ndarray, cls_1: np.ndarray,
-                     cls_2: np.ndarray) -> np.ndarray:
+    def _calc_minmax(N_cls_1: np.ndarray, N_cls_2: np.ndarray) -> np.ndarray:
         """Compute the minimum of the maximum values per class for all feat.
 
         The index i indicate the minmax of feature i.
         """
-        minmax = np.min(
-            (np.max(N[cls_1, :], axis=0), np.max(N[cls_2, :], axis=0)), axis=0)
+        if N_cls_1.size == 0 or N_cls_2.size == 0:
+            # Note: if there is no two classes, the 'overlapping region'
+            # becomes ill defined. Thus, returning '-np.inf' alongside
+            # '_calc_maxmin()' returning '+np.inf' guarantees that no
+            # example will remain into the (undefined) 'overlapping region.'
+            return -np.inf
+
+        minmax = np.min((np.max(N_cls_1, axis=0), np.max(N_cls_2, axis=0)),
+                        axis=0)
+
         return minmax
 
     @staticmethod
-    def _calc_maxmin(N: np.ndarray, cls_1: np.ndarray,
-                     cls_2: np.ndarray) -> np.ndarray:
+    def _calc_maxmin(N_cls_1: np.ndarray, N_cls_2: np.ndarray) -> np.ndarray:
         """Compute the maximum of the minimum values per class for all feat.
 
         The index i indicate the maxmin of the ith feature.
         """
-        maxmin = np.max(
-            (np.min(N[cls_1, :], axis=0), np.min(N[cls_2, :], axis=0)), axis=0)
+        if N_cls_1.size == 0 or N_cls_2.size == 0:
+            # Note: if there is no two classes, the 'overlapping region'
+            # becomes ill defined. Thus, returning '+np.inf' alongside
+            # '_calc_minmax()' returning '-np.inf' guarantees that no
+            # example will remain into the (undefined) 'overlapping region.'
+            return np.inf
+
+        maxmin = np.max((np.min(N_cls_1, axis=0), np.min(N_cls_2, axis=0)),
+                        axis=0)
+
         return maxmin
 
     @staticmethod
@@ -261,13 +274,13 @@ class MFEComplexity:
         f3 = np.zeros(ovo_comb.shape[0], dtype=float)
 
         for ind, (cls_id_1, cls_id_2) in enumerate(ovo_comb):
-            cls_1 = cls_inds[cls_id_1, :]
-            cls_2 = cls_inds[cls_id_2, :]
+            N_cls_1 = N[cls_inds[cls_id_1, :], :]
+            N_cls_2 = N[cls_inds[cls_id_2, :], :]
 
             ind_less_overlap, feat_overlap_num, _ = cls._calc_overlap(
                 N=N,
-                minmax=cls._calc_minmax(N=N, cls_1=cls_1, cls_2=cls_2),
-                maxmin=cls._calc_maxmin(N=N, cls_1=cls_1, cls_2=cls_2))
+                minmax=cls._calc_minmax(N_cls_1, N_cls_2),
+                maxmin=cls._calc_maxmin(N_cls_1, N_cls_2))
 
             f3[ind] = (feat_overlap_num[ind_less_overlap] /
                        (class_freqs[cls_id_1] + class_freqs[cls_id_2]))
@@ -339,42 +352,41 @@ class MFEComplexity:
             cls_2 = cls_inds[cls_id_2, cls_subset_union]
             N_subset = N[cls_subset_union, :]
 
-            while N_subset.size > 0:
-                # True if the example is in the overlapping region
+            # Search only on remaining features, without copying any data
+            valid_attr_inds = np.arange(N_subset.shape[1])
+            N_view = N_subset[:, valid_attr_inds]
+
+            while N_view.size > 0:
+                N_cls_1, N_cls_2 = N_view[cls_1, :], N_view[cls_2, :]
+
+                # Note: 'feat_overlapped_region' is a boolean vector with
+                # True values if the example is in the overlapping region
                 ind_less_overlap, _, feat_overlapped_region = (
                     cls._calc_overlap(
-                        N=N_subset,
-                        minmax=cls._calc_minmax(N_subset, cls_1, cls_2),
-                        maxmin=cls._calc_maxmin(N_subset, cls_1, cls_2)))
+                        N=N_view,
+                        minmax=cls._calc_minmax(N_cls_1, N_cls_2),
+                        maxmin=cls._calc_maxmin(N_cls_1, N_cls_2)))
 
-                # boolean that if True, this example is in the overlapping
+                # Boolean that if True, this example is in the overlapping
                 # region
                 overlapped_region = feat_overlapped_region[:, ind_less_overlap]
 
-                # removing the non-overlapping instances
+                # Removing the non-overlapping instances
                 N_subset = N_subset[overlapped_region, :]
                 cls_1 = cls_1[overlapped_region]
                 cls_2 = cls_2[overlapped_region]
 
-                inst_num_1 = np.sum(cls_1)
-                inst_num_2 = np.sum(cls_2)
-
-                if inst_num_1 == 0 or inst_num_2 == 0:
-                    # All instances are already discriminated, thus the
-                    # procecure may stop, and the results must be 0 (by
-                    # definition of F4 measure, which is the ratio of
-                    # examples not discriminated after applying its
-                    # algorithm multiple times.)
-                    N_subset = np.array([])
-
-                else:
-                    # removing the most efficient feature
-                    N_subset = np.delete(N_subset, ind_less_overlap, axis=1)
+                # Removing the most efficient feature
+                # Note: previous versions used to delete it directly from data
+                # 'N_subset', but that procedure takes up much more memory
+                # because each 'np.delete' operation creates a new dataset.
+                valid_attr_inds = np.delete(valid_attr_inds, ind_less_overlap)
+                N_view = N_subset[:, valid_attr_inds]
 
             subset_size = N_subset.shape[0]
 
-            f4[ind] = subset_size / (
-                class_freqs[cls_id_1] + class_freqs[cls_id_2])
+            f4[ind] = subset_size / (class_freqs[cls_id_1] +
+                                     class_freqs[cls_id_2])
 
         # The measure is computed in the literature using the mean. However, it
         # is formulated here as a meta-feature. Therefore, the post-processing
@@ -462,7 +474,7 @@ class MFEComplexity:
         # The measure is computed in the literature using the mean. However, it
         # is formulated here as a meta-feature. Therefore, the post-processing
         # should be used to get the mean and other measures as well.
-        return np.asarray(l2)
+        return l2
 
     @classmethod
     def ft_n1(cls, N: np.ndarray, y: np.ndarray,

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -1272,7 +1272,7 @@ class MFE:
 
             if verbose > 0:
                 print("Done extracting from sample dataset {}.\n"
-                      .format(it_num))
+                      .format(1 + it_num))
 
         return res
 

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -1324,11 +1324,11 @@ class MFE:
 
         arguments_fit : dict, optional
             Extra arguments for the fit method for each sampled dataset.
-            See ``.fit`` kwargs for more information.
+            See ``.fit`` method documentation for more information.
 
         arguments_extract : dict, optional
             Extra arguments for each metafeature extraction procedure.
-            See ``.extract`` kwargs for more information.
+            See ``.extract`` method documentation for more information.
 
         verbose : int, optional
             Verbosity level for this method. Please note that the

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -1548,7 +1548,7 @@ class MFE:
 
         if arguments_extract is None:
             arguments_extract = {}
-            
+
         if model_argument in arguments_fit:
             raise KeyError("Illegal argument '{}' in 'arguments_fit' (used "
                            "internally by '.extract_from_model' method.)"
@@ -1586,7 +1586,6 @@ class MFE:
             print("Finished extracting metafeatures from model.")
 
         return res
-
 
     @classmethod
     def valid_groups(cls) -> t.Tuple[str, ...]:

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -1250,6 +1250,11 @@ class MFE:
 
         res = 3 * (np.array([]),)
 
+        bootstrap_random_state = (
+            self.random_state
+            if self.random_state is not None
+            else np.random.randint(np.iinfo(np.int).max))
+
         for it_num in np.arange(sample_num):
             if verbose > 0:
                 print("Extracting from sample dataset {} of {} ({:.2f}%)..."
@@ -1257,9 +1262,15 @@ class MFE:
                               sample_num,
                               100.0 * (1 + it_num) / sample_num))
 
+            # Note: setting random state to prevent same sample indices due
+            # to random states set during fit/extraction
+            np.random.seed(bootstrap_random_state)
+            bootstrap_random_state += 1
+
             sample_inds = np.random.randint(
                 self.X.shape[0],
                 size=self.X.shape[0])
+
             X_sample = self.X[sample_inds, :]
             y_sample = self.y[sample_inds] if self.y is not None else None
 

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -1418,7 +1418,7 @@ class MFE:
             print("Done.")
 
         if return_avg_val:
-            mtf_vals = np.mean(mtf_vals, axis=0)
+            mtf_vals = np.nanmean(mtf_vals, axis=0)
 
         if self.timeopt:
             if return_avg_val:

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -1232,7 +1232,7 @@ class MFE:
                 cur_mtf_names, cur_mtf_vals, cur_mtf_time = args
 
             if mtf_names.size:
-                mtf_vals[it_num, :] = cur_mtf_vals
+                mtf_vals[:, it_num] = cur_mtf_vals
 
                 if self.timeopt:
                     mtf_time += cur_mtf_time
@@ -1240,8 +1240,8 @@ class MFE:
             else:
                 mtf_names = np.asarray(cur_mtf_names, dtype=str)
                 mtf_vals = np.zeros(
-                    (sample_num, len(cur_mtf_vals)), dtype=float)
-                mtf_vals[0, :] = cur_mtf_vals
+                    (len(cur_mtf_vals), sample_num), dtype=float)
+                mtf_vals[:, 0] = cur_mtf_vals
 
                 if self.timeopt:
                     mtf_time = np.asarray(cur_mtf_time, dtype=float)
@@ -1318,9 +1318,12 @@ class MFE:
             If True, return the average value for both the metafeature
             values and the time elapsed for its extraction (if any
             ``measure_time`` option was chosen.) If False, then all
-            extracted metafeature values are returned as a 2D numpy array,
-            and the time elapsed will be the sum of all extractions for
-            each metafeature.
+            extracted metafeature values are returned as a 2D numpy array
+            of shape (`metafeature_num`, `sample_num`) (i.e., each row
+            represents a distinct metafeature, and each column is the
+            value of the corresponding metafeature extracted from a
+            distinct sample dataset) and the time elapsed will be the
+            sum of all extractions for each metafeature.
 
         arguments_fit : dict, optional
             Extra arguments for the fit method for each sampled dataset.
@@ -1343,15 +1346,17 @@ class MFE:
             The same return value format of the ``extract`` method, appended
             with the confidence intervals as a new sequence of values in the
             form (interval_low, interval_high) for each corresponding
-            metafeature.
+            metafeature, and with shape (`metafeature_num`, 2) (i.e., the rows
+            represents each metafeature and the columns each interval limit.)
 
             if ``return_avg_val`` is True, the metafeature values and the
             time elapsed for extraction for each item (if any ``measure_time``
             options was chosen) will be the average value between all
             extractions. Otherwise, all extract metafeature values will be
-            returned as a 2D numpy array (where each row is from a distinct
-            sampled dataset), and time time elapsed will be the sum of all
-            extractions for the corresponding metafeature.
+            returned as a 2D numpy array (where each columns is from a distinct
+            sampled dataset, and each row is a distinct metafeature), and the
+            time elapsed will be the sum of all extractions for the
+            corresponding metafeature.
 
         Raises
         ------
@@ -1412,13 +1417,13 @@ class MFE:
 
         _half_sig_level = 0.5 * (1.0 - confidence)
         interval = [_half_sig_level, 1.0 - _half_sig_level]
-        mtf_conf_int = np.quantile(a=mtf_vals, q=interval, axis=0)
+        mtf_conf_int = np.quantile(a=mtf_vals, q=interval, axis=1).T
 
         if verbose > 0:
             print("Done.")
 
         if return_avg_val:
-            mtf_vals = np.nanmean(mtf_vals, axis=0)
+            mtf_vals = np.nanmean(mtf_vals, axis=1)
 
         if self.timeopt:
             if return_avg_val:

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -1250,6 +1250,11 @@ class MFE:
 
         res = 3 * (np.array([]),)
 
+        if self.random_state is None:
+            # Enforce pseudo-random behaviour to avoid previously set
+            # random seeds out of this context
+            np.random.seed()
+
         bootstrap_random_state = (
             self.random_state
             if self.random_state is not None

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -1207,13 +1207,13 @@ class MFE:
 
         return res_names, res_vals
 
-    def _extract_with_boostrap(self,
-                               extractor: "MFE",
-                               sample_num: int,
-                               arguments_fit: t.Dict[str, t.Any],
-                               arguments_extract: t.Dict[str, t.Any],
-                               verbose: int = 0) -> t.Tuple[np.ndarray, ...]:
-        """Extract metafeatures using bootstrap."""
+    def _extract_with_bootstrap(self,
+                                extractor: "MFE",
+                                sample_num: int,
+                                arguments_fit: t.Dict[str, t.Any],
+                                arguments_extract: t.Dict[str, t.Any],
+                                verbose: int = 0) -> t.Tuple[np.ndarray, ...]:
+        """Extract metafeatures using bootstrapping."""
         if self.X is None:
             raise TypeError("Fitted data not found. Please call 'fit' "
                             "method first.")
@@ -1409,7 +1409,7 @@ class MFE:
             measure_time=self.timeopt,
             random_state=_random_state)
 
-        mtf_names, mtf_vals, mtf_time = self._extract_with_boostrap(
+        mtf_names, mtf_vals, mtf_time = self._extract_with_bootstrap(
             extractor=extractor,
             sample_num=sample_num,
             verbose=verbose,

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -1253,7 +1253,7 @@ class MFE:
         bootstrap_random_state = (
             self.random_state
             if self.random_state is not None
-            else np.random.randint(np.iinfo(np.int).max))
+            else np.random.randint(2 ** 20 - 1))
 
         for it_num in np.arange(sample_num):
             if verbose > 0:

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -263,8 +263,8 @@ class TestArchitecture:
 
         in_range_prop = np.zeros(len(mtf_names), dtype=float)
 
-        for mtf_ind, cur_mtf_vals in enumerate(mtf_vals.T):
-            int_low, int_high = mtf_conf_int[:, mtf_ind]
+        for mtf_ind, cur_mtf_vals in enumerate(mtf_vals):
+            int_low, int_high = mtf_conf_int[mtf_ind, :]
             in_range_prop[mtf_ind] = np.sum(np.logical_and(
                 int_low <= cur_mtf_vals, cur_mtf_vals <= int_high)) / len(cur_mtf_vals)
 
@@ -287,3 +287,18 @@ class TestArchitecture:
         with pytest.raises(ValueError):
             MFE().fit(
                 X.values, y.values).extract_with_confidence(confidence=1.0001)
+
+    @pytest.mark.parametrize("return_avg_val", (True, False))
+    def test_extract_with_confidence_time(self, return_avg_val):
+        X, y = load_xy(2)
+
+        res = MFE(
+            features=["mean", "inst_num"],
+            measure_time="avg").fit(
+                X=X.values, y=y.values).extract_with_confidence(
+                    sample_num=3,
+                    return_avg_val=return_avg_val)
+
+        mtf_names, mtf_vals, mtf_time, mtf_conf_int = res
+
+        assert (len(mtf_names) == len(mtf_vals) == len(mtf_time) == len(mtf_conf_int))

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -298,7 +298,7 @@ class TestArchitecture:
 
     @pytest.mark.parametrize("confidence", (0.95, 0.99))
     def test_extract_with_confidence(self, confidence):
-        X, y = load_xy(2)
+        X, y = utils.load_xy(2)
 
         mtf_names, mtf_vals, mtf_conf_int = MFE(
             groups="all",
@@ -324,14 +324,14 @@ class TestArchitecture:
             MFE().extract_with_confidence()
 
     def test_extract_with_confidence_invalid2(self):
-        X, y = load_xy(2)
+        X, y = utils.load_xy(2)
 
         with pytest.raises(ValueError):
             MFE().fit(
                 X.values, y.values).extract_with_confidence(confidence=-0.0001)
 
     def test_extract_with_confidence_invalid3(self):
-        X, y = load_xy(2)
+        X, y = utils.load_xy(2)
 
         with pytest.raises(ValueError):
             MFE().fit(
@@ -339,7 +339,7 @@ class TestArchitecture:
 
     @pytest.mark.parametrize("return_avg_val", (True, False))
     def test_extract_with_confidence_time(self, return_avg_val):
-        X, y = load_xy(2)
+        X, y = utils.load_xy(2)
 
         res = MFE(
             features=["mean", "nr_inst", "unknown"],
@@ -353,7 +353,7 @@ class TestArchitecture:
         assert (len(mtf_names) == len(mtf_vals) == len(mtf_time) == len(mtf_conf_int))
 
     def test_extract_with_confidence_random_state1(self):
-        X, y = load_xy(2)
+        X, y = utils.load_xy(2)
 
         _, mtf_vals_1, mtf_conf_int_1 = MFE(
             features=["mean", "sd"], random_state=16).fit(
@@ -369,7 +369,7 @@ class TestArchitecture:
                 np.allclose(mtf_conf_int_1, mtf_conf_int_2))
 
     def test_extract_with_confidence_random_state2(self):
-        X, y = load_xy(2)
+        X, y = utils.load_xy(2)
 
         _, mtf_vals_1, mtf_conf_int_1 = MFE(
             features=["mean", "sd"], random_state=16).fit(
@@ -385,7 +385,7 @@ class TestArchitecture:
                 np.any(~np.isclose(mtf_conf_int_1, mtf_conf_int_2)))
 
     def test_extract_with_confidence_random_state3(self):
-        X, y = load_xy(2)
+        X, y = utils.load_xy(2)
 
         np.random.seed(1234)
         _, mtf_vals_1, mtf_conf_int_1 = MFE(

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -352,6 +352,19 @@ class TestArchitecture:
 
         assert (len(mtf_names) == len(mtf_vals) == len(mtf_time) == len(mtf_conf_int))
 
+    def test_extract_with_confidence_multiple_conf_level(self):
+        X, y = utils.load_xy(2)
+
+        confidence = [0.8, 0.9, 0.7]
+
+        mtf_conf_int = MFE(
+            features=["mean", "nr_inst", "unknown"]).fit(
+                X=X.values, y=y.values).extract_with_confidence(
+                    sample_num=2,
+                    confidence=confidence)[2]
+
+        assert 2 * len(confidence) == mtf_conf_int.shape[1]
+
     def test_extract_with_confidence_random_state1(self):
         X, y = utils.load_xy(2)
 

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -293,7 +293,7 @@ class TestArchitecture:
         X, y = load_xy(2)
 
         res = MFE(
-            features=["mean", "inst_num"],
+            features=["mean", "nr_inst", "unknown"],
             measure_time="avg").fit(
                 X=X.values, y=y.values).extract_with_confidence(
                     sample_num=3,
@@ -302,3 +302,53 @@ class TestArchitecture:
         mtf_names, mtf_vals, mtf_time, mtf_conf_int = res
 
         assert (len(mtf_names) == len(mtf_vals) == len(mtf_time) == len(mtf_conf_int))
+
+    def test_extract_with_confidence_random_state_1(self):
+        X, y = load_xy(2)
+
+        _, mtf_vals_1, mtf_conf_int_1 = MFE(
+            features=["mean", "sd"], random_state=16).fit(
+                X=X.values, y=y.values).extract_with_confidence(
+                    sample_num=3)
+
+        _, mtf_vals_2, mtf_conf_int_2 = MFE(
+            features=["mean", "sd"], random_state=16).fit(
+                X=X.values, y=y.values).extract_with_confidence(
+                    sample_num=3)
+
+        assert (np.allclose(mtf_vals_1, mtf_vals_2) and
+                np.allclose(mtf_conf_int_1, mtf_conf_int_2))
+
+    def test_extract_with_confidence_random_state_2(self):
+        X, y = load_xy(2)
+
+        _, mtf_vals_1, mtf_conf_int_1 = MFE(
+            features=["mean", "sd"], random_state=16).fit(
+                X=X.values, y=y.values).extract_with_confidence(
+                    sample_num=3)
+
+        _, mtf_vals_2, mtf_conf_int_2 = MFE(
+            features=["mean", "sd"], random_state=17).fit(
+                X=X.values, y=y.values).extract_with_confidence(
+                    sample_num=3)
+
+        assert (np.any(~np.isclose(mtf_vals_1, mtf_vals_2)) and
+                np.any(~np.isclose(mtf_conf_int_1, mtf_conf_int_2)))
+
+    def test_extract_with_confidence_random_state_3(self):
+        X, y = load_xy(2)
+
+        np.random.seed(1234)
+        _, mtf_vals_1, mtf_conf_int_1 = MFE(
+            features=["mean", "sd"]).fit(
+                X=X.values, y=y.values).extract_with_confidence(
+                    sample_num=3)
+
+        np.random.seed(1234)
+        _, mtf_vals_2, mtf_conf_int_2 = MFE(
+            features=["mean", "sd"]).fit(
+                X=X.values, y=y.values).extract_with_confidence(
+                    sample_num=3)
+
+        assert (np.any(~np.isclose(mtf_vals_1, mtf_vals_2)) and
+                np.any(~np.isclose(mtf_conf_int_1, mtf_conf_int_2)))

--- a/tests/test_complexity.py
+++ b/tests/test_complexity.py
@@ -2,6 +2,7 @@
 import pytest
 
 from pymfe.mfe import MFE
+from pymfe.complexity import MFEComplexity
 from tests.utils import load_xy
 import numpy as np
 
@@ -139,3 +140,34 @@ class TestComplexity:
         value = mfe.extract()[1]
 
         assert np.allclose(value, exp_value, equal_nan=True)
+
+    @pytest.mark.parametrize("num_inst_1, num_inst_2, expected_val", (
+        (4, 0, (0, 0)),
+        (0, 5, (0, 0)),
+        (4, 6, (7, 6)),
+    ))
+    def test_overlapping_area(self, num_inst_1, num_inst_2, expected_val):
+        N_cls_1 = np.asarray([
+            [0, 0],
+            [1, 1],
+            [1, 0],
+            [0, 1],
+        ])[:num_inst_1, :]
+
+        N_cls_2 = np.asarray([
+            [2, 0.5],
+            [0.5, 0.5],
+            [0, 0],
+            [-1, -1],
+            [-1, 0],
+            [0, -1],
+        ])[:num_inst_2, :]
+
+        ind_less_overlap, feat_overlap_num, _ = (
+            MFEComplexity._calc_overlap(
+                N=np.vstack((N_cls_1, N_cls_2)),
+                minmax=MFEComplexity._calc_minmax(N_cls_1, N_cls_2),
+                maxmin=MFEComplexity._calc_maxmin(N_cls_1, N_cls_2)))
+
+        assert (ind_less_overlap == np.argmin(feat_overlap_num) and
+                np.allclose(feat_overlap_num, expected_val))

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -100,3 +100,16 @@ class TestOutput:
         captured = capsys.readouterr().out
 
         assert (not msg_expected) or captured
+
+    @pytest.mark.parametrize("verbosity, msg_expected", [
+        (0, False),
+        (1, True),
+    ])
+    def test_verbosity_with_confidence(self, verbosity, msg_expected, capsys):
+        X, y = load_xy(2)
+
+        MFE().extract_with_confidence(model, verbose=verbosity)
+
+        captured = capsys.readouterr().out
+
+        assert ((not msg_expected) and (not captured)) or (msg_expected and captured)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -108,7 +108,7 @@ class TestOutput:
     def test_verbosity_with_confidence(self, verbosity, msg_expected, capsys):
         X, y = load_xy(2)
 
-        MFE().extract_with_confidence(model, verbose=verbosity)
+        MFE().fit(X.values, y.values).extract_with_confidence(verbose=verbosity)
 
         captured = capsys.readouterr().out
 


### PR DESCRIPTION
## Major changes
- Added 'extract_with_confidence' method, which extracts the metafeatures alongside its confidence intervals (using bootstrap) given a 'confidence' level.
- Added tests for 'extract_with_confidence' method.
- Added support for extraction of multiple confidence intervals simultaneously.

## Fixes
Those glitches were detected while testing the new bootstrapping method.
- Fixed a glitch in a clustering module method, where 'np.sum', 'np.min' and 'np.max' was not working as expected with 'pairwise_norm_interclass_dist', because this array is not a rectangular array (or a proper 2-D array, but instead a 1-D array of arrays.)
- Fixed a glitch in 'ft_f4' metafeature, where a ill defined 'overlapping area' could had instances from a single class. This fix was done by returning '+np.inf' and '-np.inf' by, respectively, _calc_maxmin() and _calc_minmax() methods when there is 0 instances from some class, generating an empty 'overlapping region' for that ill defined case.