### PR TITLE
Added a default value for attr_conc's 'max_attr_num' parameter

### DIFF
--- a/pymfe/info_theory.py
+++ b/pymfe/info_theory.py
@@ -203,7 +203,7 @@ class MFEInfoTheory:
     @classmethod
     def ft_attr_conc(cls,
                      C: np.ndarray,
-                     max_attr_num: t.Optional[int] = None,
+                     max_attr_num: t.Optional[int] = 12,
                      random_state: t.Optional[int] = None) -> np.ndarray:
         """Compute concentration coef. of each pair of distinct attributes.
 

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -1383,7 +1383,7 @@ class MFE:
         if include_references:
             aux = docstring.split("References\n        ----------\n")
             if len(aux) >= 2:
-                split = aux[1].split(f".. [")
+                split = aux[1].split(".. [")
                 if len(split) >= 2:
                     del split[0]
                     for spl in split:

--- a/tests/test_infotheo.py
+++ b/tests/test_infotheo.py
@@ -36,7 +36,7 @@ class TestInfoTheo:
             ###################
             # Categorical data
             ###################
-            (1, "attr_conc", [0.01682327, 0.04715381], False),
+            (1, "attr_conc", [0.017922703, 0.057748884], False),
             (1, "attr_ent", [0.59014829, 0.33852165], False),
             (1, "class_conc", [0.02313025, 0.04485300], False),
             (1, "class_ent", 0.99857554, False),
@@ -44,7 +44,7 @@ class TestInfoTheo:
             (1, "joint_ent", [1.56957216, 0.33197232], False),
             (1, "mut_inf", [0.01915167, 0.03918710], False),
             (1, "ns_ratio", 29.81446298, False),
-            (1, "attr_conc", [0.01682327, 0.04715381], True),
+            (1, "attr_conc", [0.017922703, 0.057748884], True),
             (1, "attr_ent", [0.59014829, 0.33852165], True),
             (1, "class_conc", [0.02313025, 0.04485300], True),
             (1, "class_ent", 0.99857554, True),
@@ -78,7 +78,7 @@ class TestInfoTheo:
         precomp_group = GNAME if precompute else None
         X, y = load_xy(dt_id)
         mfe = MFE(
-            groups=[GNAME], features=[ft_name]).fit(
+            groups=[GNAME], features=[ft_name], random_state=1234).fit(
                 X.values, y.values, precomp_groups=precomp_group)
         value = mfe.extract()[1]
 


### PR DESCRIPTION
Resolves #84.

Added a default value for `max_attr_num` parameter of the `attr_conc` meta-feature extraction method, which is the most expensive meta-feature extraction method by far.

The default parameter was determined by a simple inspection at the feature extraction time growing rate to the number of attributes on the fitted data. The threshold accepted for the time extraction is a value less than 2 seconds.

The test dataset was the `iris` dataset. The test code used is reproduced below.

```python
from sklearn.datasets import load_iris
import numpy as np
import pymfe.mfe
import matplotlib.pyplot as plt

iris = load_iris()

arrsize = np.zeros(10)
time = np.zeros(10)

X = np.empty((iris.target.size, 0))

for i in np.arange(10):
    X = np.hstack((X, iris.data))
    print(f"{i}. Number of attributes: {X.shape[1]} ...")
    model = pymfe.mfe.MFE(features="attr_conc",
                          summary="mean",
                          measure_time="total").fit(X)
    res = model.extract(suppress_warnings=True)

    arrsize[i] = model._custom_args_ft["C"].shape[1]
    time[i] = res[2][0]

plt.plot(arrsize, time, label="time elapsed")
plt.hlines(y=np.arange(1, 1 + int(np.ceil(np.max(time)))),
           xmin=0,
           xmax=arrsize[-1],
           linestyle="dotted",
           color="red")
plt.legend()
plt.show()
```
The time cost of extraction for the `attr_conc` meta-feature does not grow significantly with the number of instance and, hence, it is not necessary to sample in the instance axis.