### PR TITLE
0.3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ notifications:
         on_failure: never
 
 after_success:
-  - codecov
+    - bash <(curl -s https://codecov.io/bash)

--- a/docs/source/new.rst
+++ b/docs/source/new.rst
@@ -6,8 +6,43 @@ The PyMFE releases are available in PyPI_ and GitHub_.
 .. _GitHub: https://github.com/ealcobaca/pymfe/releases
 
 
-Version 0.2.0
--------------
+Version 0.3.0 (Available on PyPI)
+---------------------------------
+* Metafeature extraction with confidence intervals
+
+* Pydoc fixes and package documentation/code consistency improvements
+
+  * Reformatted 'model-based' group metafeature extraction methods arguments to
+    a consistent format (all model-based metafeatures now receive a single
+    mandatory argument 'dt_model', and all other arguments are optional
+    arguments from precomputations.) Now it is much easier to use those
+    methods directly without the main class (mfe) filter, if desired.
+
+  * Now accepting user custom arguments in precomputation methods.
+
+  * Added 'extract_from_model' MFE method, making easy to extract model-based
+    metafeatures from a pre-fitted model without using the training data.
+
+* Memory issues
+
+  * Now handling memory errors in precomputations, postcomputations and
+    metafeature extraction as a regular exception.
+
+* Categorical attributes one-hot encoding option
+
+  * Added option to encode categorical attributes using one-hot encoding
+    instead of the current gray encoding.
+
+* New nan-resilient summary functions
+
+  * All summary functions now can be calculated ignoring 'nan' values, using
+    its nan-resilient version.
+
+* Online documentation improvement
+
+
+Version 0.2.0 (Available on PyPI)
+---------------------------------
 * New meta-feature groups
 
   * Complexity
@@ -35,8 +70,8 @@ Version 0.2.0
 * Statistical group updated
 
 
-Version 0.1.1
--------------
+Version 0.1.1 (Available on PyPI)
+---------------------------------
 * Bugs solved
 
    * False positive of mypy fixed

--- a/pymfe/_version.py
+++ b/pymfe/_version.py
@@ -21,4 +21,4 @@ in machine learning and AutoML.
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 
-__version__ = '0.3.a0'
+__version__ = '0.3.0'


### PR DESCRIPTION
New Version 0.3.0
------------------------
* Metafeature extraction with confidence intervals

* Pydoc fixes and package documentation/code consistency improvements

  * Reformatted 'model-based' group metafeature extraction methods arguments to
    a consistent format (all model-based metafeatures now receive a single
    mandatory argument 'dt_model', and all other arguments are optional
    arguments from precomputations.) Now it is much easier to use those
    methods directly without the main class (mfe) filter, if desired.

  * Now accepting user custom arguments in precomputation methods.

  * Added 'extract_from_model' MFE method, making easy to extract model-based
    metafeatures from a pre-fitted model without using the training data.

* Memory issues

  * Now handling memory errors in precomputations, postcomputations and
    metafeature extraction as a regular exception.

* Categorical attributes one-hot encoding option

  * Added option to encode categorical attributes using one-hot encoding
    instead of the current gray encoding.

* New nan-resilient summary functions

  * All summary functions now can be calculated ignoring 'nan' values, using
    its nan-resilient version.

* Online documentation improvement