### PR TITLE
Change 'np.linalg.eigvals' to 'np.linalg.eigvalsh' in 'ft_eigenvalues'

### DIFF
--- a/pymfe/statistical.py
+++ b/pymfe/statistical.py
@@ -565,7 +565,7 @@ class MFEStatistical:
         if cov_mat is None:
             cov_mat = np.cov(N, rowvar=False, ddof=ddof)
 
-        return np.linalg.eigvals(cov_mat)
+        return np.linalg.eigvalsh(cov_mat)
 
     @classmethod
     def ft_g_mean(


### PR DESCRIPTION
Resolves #101.

Changed the use of 'np.linalg.eigvals' in 'ft_eigenvalues' to 'np.linalg.eigvalsh', which always assumes a symmetric matrix (this is always true since we're computing the eigenvalues of a covariance matrix) and therefore always return real-valued eigenvalues.

The previous implementation showed an apparent fluke with no apparent reason with respect to the return type, returning complex-type eigenvalues which imaginary parts are always 0. I believe it has something to do with precision of floating point calculations.