### PR TITLE
Re-raise exceptions with 'from' (pylint fix)

### DIFF
--- a/pymfe/_internal.py
+++ b/pymfe/_internal.py
@@ -845,12 +845,12 @@ def process_generic_set(
             _module_name,
             "{0}{1}".format(VALID_VALUE_PREFIX, group_name.upper()),
         )
-    except AttributeError:
+    except AttributeError as err:
         raise ValueError(
             'Invalid "group_name" "{}". Check _internal '
             "module documentation to verify which ones "
             "are available for use.".format(group_name)
-        )
+        ) from err
 
     if groups_alias:
         values = convert_alias(groups_alias, values)
@@ -929,8 +929,8 @@ def process_generic_option(
 
     if value is not None and not isinstance(value, str):
         raise TypeError(
-            '"value" (group name {}) must be a string-'
-            "type object (got {}).".format(group_name, type(value))
+            '"value" (group name {}) must be a string-type object (got {}).'
+            .format(group_name, type(value))
         )
 
     processed_value = process_generic_set(
@@ -991,8 +991,8 @@ def process_summary(
 
     if not_in_group:
         raise ValueError(
-            "Unknown summary function '{0}'. "
-            "Please select values in {1}.".format(not_in_group, VALID_SUMMARY)
+            "Unknown summary function '{0}'. Please select values in {1}."
+            .format(not_in_group, VALID_SUMMARY)
         )
 
     summary_methods = []  # type: t.List[TypeExtMtdTuple]
@@ -1506,13 +1506,13 @@ def transform_cat_gray(data_categoric: np.ndarray) -> t.Optional[np.ndarray]:
         enc_data = patsy.dmatrix(formula, named_data, NA_action="raise")
         return np.asarray(enc_data, dtype=float)
 
-    except patsy.PatsyError:
+    except patsy.PatsyError as err:
         raise ValueError(
             "Categorical data encoding of type 'gray' has no "
             "support for missing values. Please handle the "
             "missing data manually before fitting it into the "
             "MFE model."
-        )
+        ) from err
 
 
 def transform_cat_onehot(
@@ -1544,13 +1544,13 @@ def transform_cat_onehot(
         try:
             one_cat_attrs.append(ohe.fit_transform(cur_attr))
 
-        except ValueError:
+        except ValueError as err:
             raise ValueError(
                 "Categorical data encoding of type 'one-hot' has "
                 "no support for missing values. Please handle the"
                 " missing data manually before fitting it into "
                 "the MFE model."
-            )
+            ) from err
 
     return np.hstack(one_cat_attrs)
 
@@ -1854,10 +1854,8 @@ def post_processing(
             if new_results:
                 if len(new_results) != len(results):
                     raise ValueError(
-                        "Postprocessing result has length '{}'. "
-                        "Expecting '{}'.".format(
-                            len(new_results), len(results)
-                        )
+                        "Postprocessing result has length '{}'. Expecting"
+                        " '{}'.".format(len(new_results), len(results))
                     )
 
                 for res_list_old, res_list_new in zip(results, new_results):

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -315,8 +315,8 @@ class MFE:
 
         else:
             raise ValueError(
-                'Invalid "num_cv_folds" argument ({0}). '
-                "Expecting an integer.".format(random_state)
+                'Invalid "num_cv_folds" argument ({0}). Expecting an integer.'
+                .format(random_state)
             )
 
         if isinstance(lm_sample_frac, int):
@@ -420,8 +420,8 @@ class MFE:
 
             if verbose >= 2:
                 print(
-                    " {} Summarizing '{}' feature with '{}' summary "
-                    "function...".format(
+                    " {} Summarizing '{}' feature with '{}' summary"
+                    " function...".format(
                         _internal.VERBOSE_BLOCK_MID_SYMBOL,
                         feature_name,
                         sm_mtd_name,
@@ -865,10 +865,8 @@ class MFE:
             and transform_cat not in _internal.VALID_TRANSFORM_CAT
         ):
             raise ValueError(
-                "Invalid 'transform_cat' value ('{}'). Must be "
-                "a value in {}.".format(
-                    transform_cat, _internal.VALID_TRANSFORM_CAT
-                )
+                "Invalid 'transform_cat' value ('{}'). Must be a value in {}."
+                .format(transform_cat, _internal.VALID_TRANSFORM_CAT)
             )
 
         data_num = self.X[:, self._attr_indexes_num]
@@ -1675,12 +1673,12 @@ class MFE:
         try:
             sklearn.utils.validation.check_is_fitted(model)
 
-        except sklearn.exceptions.NotFittedError:
+        except sklearn.exceptions.NotFittedError as err:
             raise RuntimeError(
                 "Given 'model' does not have any fitted data. "
                 "Please use its 'fit' method before using the "
                 "model with 'extract_from_model' method."
-            )
+            ) from err
 
         if arguments_fit is None:
             arguments_fit = {}


### PR DESCRIPTION
Fixes new Pylint complains about re-raising exceptions (error code 'W0707').

Now we re-raise exceptions using:

```python
except EXCEPTION as err:
    raise NEW_EXCEPTION("explanation") from err
```