### PR TITLE
Improving output structure

### DIFF
--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -1843,13 +1843,13 @@ class MFE:
                 {
                     "mtf_names": names,
                     "mtf_vals": vals,
-                    "confidance": conf,
+                    "confidence": conf,
                     "mtf_time": times
                 } if self.timeopt else
                 {
                     "mtf_names": names,
                     "mtf_vals": vals,
-                    "confidance": conf
+                    "confidence": conf
                 },
         }
 


### PR DESCRIPTION
Resolves #95 

Hi! 

I saw that Issue #95 is still open. I've tried to address some of the concerns mentioned in the thread.
The submitted changes add an `out_type` argument to specify the format in the .extract(). Thus, the output can be a tuple, dict or pd.DataFrame. 

Thanks! Best regards. :D

# Usage Examples
## Requesting output as dictionary:
```python
# Load a dataset
from sklearn.datasets import load_iris
from pymfe.mfe import MFE

data = load_iris()
y = data.target
X = data.data

# Extract default measures
mfe = MFE(features=["mean", "nr_cor_attr", "sd", "max"])
mfe.fit(X, y)
ft = mfe.extract(out_type = dict)
print(ft)
```
**Result**:
```python
{
    'mtf_names': ['max.mean', 'max.sd', 'mean.mean', 'mean.sd', 'nr_cor_attr', 'sd.mean', 'sd.sd'], 
    'mtf_vals': [5.425000000000001, 2.4431878083083722, 3.4645000000000006, 1.918485079431164, 0.5, 0.9478670787835934, 0.5712994109375844]
}
```

## Requesting output as pandas DataFrame:
```python
import pandas as pd
ft = mfe.extract(out_type = pd.DataFrame)
print(ft)
```
**Result**:
```python
   max.mean    max.sd  mean.mean   mean.sd  nr_cor_attr   sd.mean     sd.sd
0     5.425  2.443188     3.4645  1.918485          0.5  0.947867  0.571299
```
