### PR TITLE
Update and improve .extract_with_confidence() algorithm

### DIFF
--- a/pymfe/_bootstrap.py
+++ b/pymfe/_bootstrap.py
@@ -12,8 +12,6 @@ class BootstrapExtractor:
 
     def __init__(
         self,
-        X: np.ndarray,
-        y: t.Optional[np.ndarray],
         extractor,
         sample_num: int = 256,
         confidence: t.Union[float, t.Sequence[float]] = 0.95,
@@ -23,11 +21,6 @@ class BootstrapExtractor:
         random_state: t.Optional[int] = None,
     ):
         """TODO."""
-        if not isinstance(X, np.ndarray):
-            raise TypeError(
-                "Please provide a numpy array as X to perform bootstrap."
-            )
-
         _confidence = np.asfarray(confidence)
 
         if np.any(np.logical_or(_confidence <= 0.0, _confidence >= 1.0)):
@@ -37,8 +30,6 @@ class BootstrapExtractor:
                 )
             )
 
-        self.X = X
-        self.y = y
         self.sample_num = sample_num
         self.verbose = verbose
         self.random_state = random_state
@@ -48,6 +39,13 @@ class BootstrapExtractor:
         self._arguments_extract = (
             arguments_extract if arguments_extract else {}
         )
+
+        self.X = np.empty(0)
+        self.y = np.empty(0)
+        self._fit = False
+        self._mtf_names = []  # type: t.List[str]
+        self._mtf_vals = []  # type: t.List[float]
+        self._mtf_time = []  # type: t.List[float]
 
         _half_sig_level = 0.5 * (1.0 - _confidence)
         self._crit_points_inds = np.hstack(
@@ -78,31 +76,7 @@ class BootstrapExtractor:
             ),
         }
 
-    def _handle_extract_ret(
-        self,
-        mtf_vals: np.ndarray,
-        mtf_time: np.ndarray,
-        args: t.Union[t.Tuple[t.List, ...], t.Dict[str, t.Any]],
-        it_num: int,
-    ) -> t.Tuple[np.ndarray, ...]:
-        """Handle each .extraction method return value."""
-
-        if self._extractor.timeopt:
-            _, cur_mtf_vals, cur_mtf_time = self._handle_output[type(args)](
-                args
-            )
-            mtf_time += cur_mtf_time
-
-        else:
-            _, cur_mtf_vals = self._handle_output[type(args)](args)
-
-        mtf_vals[:, it_num] = cur_mtf_vals
-
-        return mtf_vals, mtf_time
-
-    def _extract_with_bootstrap(
-        self, mtf_num: int
-    ) -> t.Tuple[np.ndarray, ...]:
+    def _extract_with_bootstrap(self, mtf_num: int) -> np.ndarray:
         """Extract metafeatures using bootstrapping."""
         if self.X is None:
             raise TypeError(
@@ -110,10 +84,6 @@ class BootstrapExtractor:
             )
 
         mtf_vals = np.zeros((mtf_num, self.sample_num), dtype=float)
-        mtf_time = np.empty(0)
-
-        if self._extractor.timeopt:
-            mtf_time = np.zeros(mtf_num, dtype=float)
 
         if self.random_state is None:
             # Enforce pseudo-random behaviour to avoid previously set
@@ -151,12 +121,9 @@ class BootstrapExtractor:
 
             self._extractor.fit(X_sample, y_sample, **self._arguments_fit)
 
-            mtf_vals, mtf_time = self._handle_extract_ret(
-                mtf_vals=mtf_vals,
-                mtf_time=mtf_time,
-                args=self._extractor.extract(**self._arguments_extract),
-                it_num=it_num,
-            )
+            args = self._extractor.extract(**self._arguments_extract)
+            cur_mtf_vals = self._handle_output[type(args)](args)[1]
+            mtf_vals[:, it_num] = cur_mtf_vals
 
             if self.verbose > 0:
                 print(
@@ -165,13 +132,40 @@ class BootstrapExtractor:
                     )
                 )
 
-        return mtf_vals, mtf_time
+        return mtf_vals
 
-    def calc_conf_intervals(
-        self, mtf_vals: np.ndarray, bootstrap_vals: np.ndarray
-    ) -> np.ndarray:
+    def fit(
+        self, X: np.ndarray, y: t.Optional[np.ndarray] = None
+    ) -> "BootstrapExtractor":
         """TODO."""
-        mtf_vals = np.expand_dims(mtf_vals, axis=1)
+        self._extractor.fit(X, y, **self._arguments_fit)
+        ret_type = self._arguments_extract.get("out_type")
+        self._arguments_extract["out_type"] = tuple
+        res = self._extractor.extract(**self._arguments_extract)
+        mtf_names, mtf_vals = res[:2]  # type: ignore
+
+        if ret_type is not None:
+            self._arguments_extract["out_type"] = ret_type
+
+        else:
+            self._arguments_extract.pop("out_type")
+
+        self._mtf_names = mtf_names
+        self._mtf_vals = mtf_vals
+
+        if len(res) >= 3:
+            self._mtf_time = res[2]
+
+        self.X = self._extractor.X
+        self.y = self._extractor.y
+
+        self._fit = True
+
+        return self
+
+    def calc_conf_intervals(self, bootstrap_vals: np.ndarray) -> np.ndarray:
+        """TODO."""
+        mtf_vals = np.expand_dims(self._mtf_vals, axis=1)
 
         diff_conf_int = np.quantile(
             a=bootstrap_vals - mtf_vals, q=self._crit_points_inds, axis=1
@@ -181,33 +175,17 @@ class BootstrapExtractor:
 
         return mtf_conf_int
 
-    def extract_original_metafeatures(
-        self,
-    ) -> t.Tuple[t.Sequence[str], t.Sequence[float]]:
-        """TODO."""
-        self._extractor.fit(self.X, self.y, **self._arguments_fit)
-        ret_type = self._arguments_extract.get("out_type")
-        self._arguments_extract["out_type"] = tuple
-        mtf_names, mtf_vals = self._extractor.extract(
-            **self._arguments_extract
-        )[
-            :2
-        ]  # type: ignore
-
-        if ret_type is not None:
-            self._arguments_extract["out_type"] = ret_type
-
-        else:
-            self._arguments_extract.pop("out_type")
-
-        return mtf_names, mtf_vals
-
     def extract_with_confidence(
         self,
     ) -> t.Tuple[
         t.Sequence[str], t.Sequence[float], t.Sequence[float], np.ndarray
     ]:
         """TODO."""
+        if not self._fit:
+            raise TypeError(
+                "Please call BootstrapExtractor.fit() method before "
+                "BootstrapExtractor.extract_with_confidence()"
+            )
 
         if self.verbose > 0:
             print("Started metafeature extract with confidence interval.")
@@ -225,19 +203,17 @@ class BootstrapExtractor:
                 )
             )
 
-        mtf_names, mtf_vals = self.extract_original_metafeatures()
-
-        bootstrap_vals, mtf_time = self._extract_with_bootstrap(
-            mtf_num=len(mtf_names)
+        bootstrap_vals = self._extract_with_bootstrap(
+            mtf_num=len(self._mtf_names)
         )
 
         if self.verbose > 0:
             print("Finished metafeature extract with confidence interval.")
             print("Now getting confidence intervals...", end=" ")
 
-        mtf_conf_int = self.calc_conf_intervals(mtf_vals, bootstrap_vals)
+        mtf_conf_int = self.calc_conf_intervals(bootstrap_vals)
 
         if self.verbose > 0:
             print("Done.")
 
-        return mtf_names, mtf_vals, mtf_time, mtf_conf_int
+        return self._mtf_names, self._mtf_vals, self._mtf_time, mtf_conf_int

--- a/pymfe/_bootstrap.py
+++ b/pymfe/_bootstrap.py
@@ -4,6 +4,8 @@ import typing as t
 import numpy as np
 import pandas as pd
 
+import pymfe._internal as _internal
+
 
 class BootstrapExtractor:
     """TODO."""
@@ -13,8 +15,8 @@ class BootstrapExtractor:
         X: np.ndarray,
         y: t.Optional[np.ndarray],
         extractor,
-        sample_num: int,
-        confidence: t.Union[float, t.Sequence[float]],
+        sample_num: int = 256,
+        confidence: t.Union[float, t.Sequence[float]] = 0.95,
         arguments_fit: t.Optional[t.Dict[str, t.Any]] = None,
         arguments_extract: t.Optional[t.Dict[str, t.Any]] = None,
         verbose: int = 0,
@@ -174,9 +176,9 @@ class BootstrapExtractor:
 
         return mtf_conf_int
 
-    def extract(
+    def extract_original_metafeatures(
         self,
-    ) -> t.Tuple[t.List[str], t.List[float], t.List[float], np.ndarray]:
+    ) -> t.Tuple[t.Sequence[str], t.Sequence[float]]:
         """TODO."""
         self._extractor.fit(self.X, self.y, **self._arguments_fit)
         ret_type = self._arguments_extract.get("out_type")
@@ -192,6 +194,33 @@ class BootstrapExtractor:
 
         else:
             self._arguments_extract.pop("out_type")
+
+        return mtf_names, mtf_vals
+
+    def extract_with_confidence(
+        self,
+    ) -> t.Tuple[
+        t.Sequence[str], t.Sequence[float], t.Sequence[float], np.ndarray
+    ]:
+        """TODO."""
+
+        if self.verbose > 0:
+            print("Started metafeature extract with confidence interval.")
+            print("Random seed:")
+            print(
+                " {} For extractor model: {}".format(
+                    _internal.VERBOSE_BLOCK_END_SYMBOL,
+                    self._extractor.random_state,
+                )
+            )
+
+            print(
+                " {} For bootstrapping: {}".format(
+                    _internal.VERBOSE_BLOCK_END_SYMBOL, self.random_state
+                )
+            )
+
+        mtf_names, mtf_vals = self.extract_original_metafeatures()
 
         bootstrap_vals, mtf_time = self._extract_with_bootstrap(
             mtf_num=len(mtf_names)

--- a/pymfe/_bootstrap.py
+++ b/pymfe/_bootstrap.py
@@ -99,7 +99,7 @@ class BootstrapExtractor:
         bootstrap_random_state = (
             self.random_state
             if self.random_state is not None
-            else np.random.randint(2 ** 20 - 1)
+            else np.random.randint(np.iinfo(np.uint32).max + 1)
         )
 
         if self.verbose >= 1:

--- a/pymfe/_bootstrap.py
+++ b/pymfe/_bootstrap.py
@@ -78,11 +78,6 @@ class BootstrapExtractor:
 
     def _extract_with_bootstrap(self, mtf_num: int) -> np.ndarray:
         """Extract metafeatures using bootstrapping."""
-        if self.X is None:
-            raise TypeError(
-                "Fitted data not found. Please call 'fit' method first."
-            )
-
         mtf_vals = np.zeros((mtf_num, self.sample_num), dtype=float)
 
         if self.random_state is None:

--- a/pymfe/_bootstrap.py
+++ b/pymfe/_bootstrap.py
@@ -1,4 +1,4 @@
-"""TODO."""
+"""Metafeature extraction with empirical bootstrap confidence intervals."""
 import typing as t
 
 import numpy as np
@@ -8,7 +8,7 @@ import pymfe._internal as _internal
 
 
 class BootstrapExtractor:
-    """TODO."""
+    """Extract metafeatures with empirical bootstrap confidence intervals."""
 
     def __init__(
         self,
@@ -20,7 +20,13 @@ class BootstrapExtractor:
         verbose: int = 0,
         random_state: t.Optional[int] = None,
     ):
-        """TODO."""
+        """Extract metafeatures with confidence intervals.
+
+        The method used is the Empirical Bootstrap.
+
+        Please refer to 'MFE.extract_with_confidence' documentation for
+        more details.
+        """
         _confidence = np.asfarray(confidence)
 
         if np.any(np.logical_or(_confidence <= 0.0, _confidence >= 1.0)):
@@ -132,7 +138,7 @@ class BootstrapExtractor:
     def fit(
         self, X: np.ndarray, y: t.Optional[np.ndarray] = None
     ) -> "BootstrapExtractor":
-        """TODO."""
+        """Fit data into the model."""
         self._extractor.fit(X, y, **self._arguments_fit)
         ret_type = self._arguments_extract.get("out_type")
         self._arguments_extract["out_type"] = tuple
@@ -159,7 +165,26 @@ class BootstrapExtractor:
         return self
 
     def calc_conf_intervals(self, bootstrap_vals: np.ndarray) -> np.ndarray:
-        """TODO."""
+        """Calculate bootstrap confidence intervals.
+
+        Parameters
+        ----------
+        bootstrap_vals : :obj:`np.ndarray`
+            Metafeatures extracted from bootstrap resampling (check
+            `BootstrapExtractor.extract_with_confidence` method
+            documentation for more information). Must have shape
+            (metafeature_num, resample_num).
+
+        Returns
+        -------
+        :obj:`np.ndarray`
+            Confidence interval for the data sample metafeatures. Will
+            have shape (metafeature_num, 2 * C), where C is the number
+            of distinct confidence levels fitted in this model. For each
+            column, the even indices (starting from 0) are the confidence
+            intervals lower bounds, while the odd indices are confidence
+            intervals upper bounds.
+        """
         mtf_vals = np.expand_dims(self._mtf_vals, axis=1)
 
         diff_conf_int = np.quantile(
@@ -175,7 +200,19 @@ class BootstrapExtractor:
     ) -> t.Tuple[
         t.Sequence[str], t.Sequence[float], t.Sequence[float], np.ndarray
     ]:
-        """TODO."""
+        """Extract metafeatures with empirical bootstrap confidence intervals.
+
+        Returns
+        -------
+        tuple of sequences
+            The sequences of values are organized as follows:
+            Metafeature names, metafeature values, metafeature extraction time
+            (if provided by the fitted MFE extractor. Otherwise, return an
+            empty list) and the confidence intervals.
+            Check the `Bootstrap.calc_conf_intervals` method documentation for
+            a more detailed explanation about the confidence intervals data
+            shape.
+        """
         if not self._fit:
             raise TypeError(
                 "Please call BootstrapExtractor.fit() method before "

--- a/pymfe/_bootstrap.py
+++ b/pymfe/_bootstrap.py
@@ -37,6 +37,9 @@ class BootstrapExtractor:
                 )
             )
 
+        if _confidence.ndim == 0:
+            _confidence = np.expand_dims(_confidence, axis=0)
+
         self.sample_num = sample_num
         self.verbose = verbose
         self.random_state = random_state

--- a/pymfe/_bootstrap.py
+++ b/pymfe/_bootstrap.py
@@ -23,6 +23,11 @@ class BootstrapExtractor:
         random_state: t.Optional[int] = None,
     ):
         """TODO."""
+        if not isinstance(X, np.ndarray):
+            raise TypeError(
+                "Please provide a numpy array as X to perform bootstrap."
+            )
+
         _confidence = np.asfarray(confidence)
 
         if np.any(np.logical_or(_confidence <= 0.0, _confidence >= 1.0)):

--- a/pymfe/_bootstrap.py
+++ b/pymfe/_bootstrap.py
@@ -1,0 +1,206 @@
+"""TODO."""
+import typing as t
+
+import numpy as np
+import pandas as pd
+
+
+_TypeExtract = t.Union[t.Tuple[t.List, ...], t.Dict[str, t.List], pd.DataFrame]
+
+
+class BootstrapExtractor:
+    """TODO."""
+
+    def __init__(
+        self,
+        X: np.ndarray,
+        y: t.Optional[np.ndarray],
+        extractor,
+        sample_num: int,
+        confidence: np.ndarray,
+        arguments_fit: t.Optional[t.Dict[str, t.Any]] = None,
+        arguments_extract: t.Optional[t.Dict[str, t.Any]] = None,
+        verbose: int = 0,
+        random_state: t.Optional[int] = None,
+    ):
+        """TODO."""
+        if np.any(np.logical_or(confidence <= 0.0, confidence >= 1.0)):
+            raise ValueError(
+                "'confidence' must be in (0.0, 1.0) range (got {}.)".format(
+                    confidence
+                )
+            )
+
+        self.X = X
+        self.y = y
+        self.sample_num = sample_num
+        self.verbose = verbose
+        self.random_state = random_state
+
+        self._extractor = extractor
+        self._arguments_fit = arguments_fit
+        self._arguments_extract = arguments_extract
+
+        _half_sig_level = 0.5 * (1.0 - confidence)
+        self._crit_points_inds = np.hstack(
+            (1.0 - _half_sig_level, _half_sig_level)
+        )
+
+        self._handle_output = {
+            tuple: lambda args: args,
+            dict: lambda args: (
+                args["mtf_names"],
+                args["mtf_vals"],
+                args["mtf_time"],
+            )
+            if self._extractor.timeopt
+            else (
+                args["mtf_names"],
+                args["mtf_vals"],
+            ),
+            pd.DataFrame: lambda args: (
+                list(args.columns),
+                args.values[0],
+                args.values[1],
+            )
+            if self._extractor.timeopt
+            else (
+                list(args.columns),
+                args.values[0],
+            ),
+        }
+
+    def _handle_extract_ret(
+        self,
+        mtf_vals: np.ndarray,
+        mtf_time: np.ndarray,
+        args: t.Union[t.Tuple[t.List, ...], t.Dict[str, t.Any]],
+        it_num: int,
+    ) -> t.Tuple[np.ndarray, ...]:
+        """Handle each .extraction method return value."""
+
+        if self._extractor.timeopt:
+            _, cur_mtf_vals, cur_mtf_time = self._handle_output[type(args)](
+                args
+            )
+            mtf_time += cur_mtf_time
+
+        else:
+            _, cur_mtf_vals = self._handle_output[type(args)](args)
+
+        mtf_vals[:, it_num] = cur_mtf_vals
+
+        return mtf_vals, mtf_time
+
+    def _extract_with_bootstrap(
+        self, mtf_num: int
+    ) -> t.Tuple[np.ndarray, ...]:
+        """Extract metafeatures using bootstrapping."""
+        if self.X is None:
+            raise TypeError(
+                "Fitted data not found. Please call 'fit' method first."
+            )
+
+        mtf_vals = np.zeros((mtf_num, self.sample_num), dtype=float)
+        mtf_time = np.empty(0)
+
+        if self._extractor.timeopt:
+            mtf_time = np.zeros(mtf_num, dtype=float)
+
+        if self.random_state is None:
+            # Enforce pseudo-random behaviour to avoid previously set
+            # random seeds out of this context
+            np.random.seed()
+
+        bootstrap_random_state = (
+            self.random_state
+            if self.random_state is not None
+            else np.random.randint(2 ** 20 - 1)
+        )
+
+        for it_num in np.arange(self.sample_num):
+            if self.verbose > 0:
+                print(
+                    "Extracting from sample dataset {} of {} ({:.2f}%)..."
+                    "".format(
+                        1 + it_num,
+                        self.sample_num,
+                        100.0 * (1 + it_num) / self.sample_num,
+                    )
+                )
+
+            # Note: setting random state to prevent same sample indices due
+            # to random states set during fit/extraction
+            np.random.seed(bootstrap_random_state)
+            bootstrap_random_state += 1
+
+            sample_inds = np.random.randint(
+                self.X.shape[0], size=self.X.shape[0]
+            )
+
+            X_sample = self.X[sample_inds, :]
+            y_sample = self.y[sample_inds] if self.y is not None else None
+
+            self._extractor.fit(X_sample, y_sample, **self._arguments_fit)
+
+            mtf_vals, mtf_time = self._handle_extract_ret(
+                mtf_vals=mtf_vals,
+                mtf_time=mtf_time,
+                args=self._extractor.extract(**self._arguments_extract),
+                it_num=it_num,
+            )
+
+            if self.verbose > 0:
+                print(
+                    "Done extracting from sample dataset {}.\n".format(
+                        1 + it_num
+                    )
+                )
+
+        return mtf_vals, mtf_time
+
+    def calc_conf_intervals(
+        self, mtf_vals: np.ndarray, bootstrap_vals: np.ndarray
+    ) -> np.ndarray:
+        """TODO."""
+        mtf_vals = np.expand_dims(mtf_vals, axis=1)
+
+        diff_conf_int = np.quantile(
+            a=bootstrap_vals - mtf_vals, q=self._crit_points_inds, axis=1
+        ).T
+
+        mtf_conf_int = -diff_conf_int + mtf_vals
+
+        return mtf_conf_int
+
+    def extract(self) -> _TypeExtract:
+        """TODO."""
+        self._extractor.fit(self.X, self.y, **self._arguments_fit)
+        ret_type = self._arguments_extract.get("out_type")
+        self._arguments_extract["out_type"] = tuple
+        mtf_names, mtf_vals = self._extractor.extract(
+            **self._arguments_extract
+        )[
+            :2
+        ]  # type: ignore
+
+        if ret_type is not None:
+            self._arguments_extract["out_type"] = ret_type
+
+        else:
+            self._arguments_extract.pop("out_type")
+
+        bootstrap_vals, mtf_time = self._extract_with_bootstrap(
+            mtf_num=len(mtf_names)
+        )
+
+        if self.verbose > 0:
+            print("Finished metafeature extract with confidence interval.")
+            print("Now getting confidence intervals...", end=" ")
+
+        mtf_conf_int = self.calc_conf_intervals(mtf_vals, bootstrap_vals)
+
+        if self.verbose > 0:
+            print("Done.")
+
+        return mtf_names, mtf_vals, mtf_time, mtf_conf_int

--- a/pymfe/_internal.py
+++ b/pymfe/_internal.py
@@ -1138,8 +1138,10 @@ def process_features(
         for unknown_ft in processed_ft:
             warnings.warn(
                 "Unknown feature '{}'. You can check available "
-                "feature names with either 'valid_metafeatures()'"
-                " or 'metafeature_description()' methods.".format(unknown_ft),
+                "feature names with either 'MFE.valid_metafeatures()'"
+                " or 'MFE.metafeature_description()' methods.".format(
+                    unknown_ft
+                ),
                 UserWarning,
             )
 

--- a/pymfe/_summary.py
+++ b/pymfe/_summary.py
@@ -50,7 +50,7 @@ def sum_histogram(
     try:
         freqs, _ = np.histogram(values, bins=bins)
 
-    except ValueError:
+    except (ValueError, IndexError):
         return np.full(bins, fill_value=np.nan)
 
     if normalize:

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -1619,16 +1619,8 @@ class MFE:
         dataset is instantiated within this method and, therefore, this
         method does not affect the current model (if any) by any means.
         """
-        _confidence = np.asarray(confidence, dtype=float)
-
         if self.random_state is not None:
             np.random.seed(self.random_state)
-
-        if arguments_fit is None:
-            arguments_fit = {}
-
-        if arguments_extract is None:
-            arguments_extract = {}
 
         # Note: the metafeature extraction random seed will be fixed due
         # to the random indices while bootstrapping the fitted data.
@@ -1664,7 +1656,7 @@ class MFE:
             y=self.y,
             extractor=surrogate_extractor,
             sample_num=sample_num,
-            confidence=_confidence,
+            confidence=confidence,
             arguments_fit=arguments_fit,
             arguments_extract=arguments_extract,
             verbose=verbose,
@@ -1679,7 +1671,7 @@ class MFE:
         ) = bootstrap_extractor.extract()
 
         if self.timeopt:
-            mtf_time /= sample_num
+            mtf_time = list(np.asfarray(mtf_time) / sample_num)
 
         _deal_types = {
             tuple: lambda names, vals, conf, times=[]: (
@@ -1705,7 +1697,7 @@ class MFE:
         }
 
         # Check if the type was defined previously
-        if "out_type" in arguments_extract:
+        if arguments_extract and "out_type" in arguments_extract:
             out_type = arguments_extract["out_type"]
         else:
             out_type = tuple

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -1613,35 +1613,27 @@ class MFE:
         ValueError
             If ``confidence`` is not in (0.0, 1.0) range.
 
+        TypeError
+            If no data was fit into the model previously.
+
         Notes
         -----
         The model used to fit and extract metafeatures for each sampled
         dataset is instantiated within this method and, therefore, this
         method does not affect the current model (if any) by any means.
         """
+        if not isinstance(self.X, np.ndarray):
+            raise TypeError(
+                "Data not found. Please use MFE.fit() method "
+                "before MFE.extract_with_confidence()."
+            )
+
         if self.random_state is not None:
             np.random.seed(self.random_state)
 
         # Note: the metafeature extraction random seed will be fixed due
         # to the random indices while bootstrapping the fitted data.
         _random_state = self.random_state if self.random_state else 1234
-
-        if verbose > 0:
-            print("Started metafeature extract with confidence interval.")
-            print("Random seed:")
-            print(
-                " {} For extractor model: {}{}".format(
-                    _internal.VERBOSE_BLOCK_END_SYMBOL,
-                    _random_state,
-                    "" if self.random_state else " (chosen by default)",
-                )
-            )
-
-            print(
-                " {} For bootstrapping: {}".format(
-                    _internal.VERBOSE_BLOCK_END_SYMBOL, self.random_state
-                )
-            )
 
         surrogate_extractor = MFE(
             features=self.features,
@@ -1668,7 +1660,7 @@ class MFE:
             mtf_vals,
             mtf_time,
             mtf_conf_int,
-        ) = bootstrap_extractor.extract()
+        ) = bootstrap_extractor.extract_with_confidence()
 
         if self.timeopt:
             mtf_time = list(np.asfarray(mtf_time) / sample_num)

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -1798,7 +1798,14 @@ class MFE:
         )  # Returns a t.Tuple[t.List,...]
 
         extractor.fit(self.X, self.y, **arguments_fit)
-        mtf_vals = extractor.extract(**arguments_extract)[1]
+        ret_type = arguments_extract.get("out_type")
+        arguments_extract["out_type"] = tuple
+        mtf_vals = extractor.extract(**arguments_extract)[1]  # type: ignore
+        arguments_extract.pop("out_type")
+
+        if ret_type is not None:
+            arguments_extract["out_type"] = ret_type
+
         mtf_vals = np.expand_dims(mtf_vals, axis=1)
 
         if verbose > 0:

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -1660,7 +1660,7 @@ class MFE:
             arguments_fit=arguments_fit,
             arguments_extract=arguments_extract,
             verbose=verbose,
-            random_state=_random_state,
+            random_state=self.random_state,
         )
 
         (

--- a/pymfe/mfe.py
+++ b/pymfe/mfe.py
@@ -1644,8 +1644,6 @@ class MFE:
         )
 
         bootstrap_extractor = _bootstrap.BootstrapExtractor(
-            X=self.X,
-            y=self.y,
             extractor=surrogate_extractor,
             sample_num=sample_num,
             confidence=confidence,
@@ -1655,15 +1653,14 @@ class MFE:
             random_state=self.random_state,
         )
 
+        bootstrap_extractor.fit(self.X, self.y)
+
         (
             mtf_names,
             mtf_vals,
             mtf_time,
             mtf_conf_int,
         ) = bootstrap_extractor.extract_with_confidence()
-
-        if self.timeopt:
-            mtf_time = list(np.asfarray(mtf_time) / sample_num)
 
         _deal_types = {
             tuple: lambda names, vals, conf, times=[]: (

--- a/pymfe/statistical.py
+++ b/pymfe/statistical.py
@@ -212,6 +212,7 @@ class MFEStatistical:
         cls,
         N: np.ndarray,
         y: np.ndarray,
+        max_iter: int = 500,
     ) -> np.ndarray:
         """Calculate the Canonical Correlations between ``N`` and ``y.``
 
@@ -235,21 +236,20 @@ class MFEStatistical:
         # whenever less than 'n_components' are got. However, this is
         # already taken into account in this function, so no need for
         # those warnings.
-        warnings.filterwarnings("ignore", category=UserWarning)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=UserWarning)
 
-        cca_model = sklearn.cross_decomposition.CCA(
-            n_components=n_components, max_iter=500
-        )
+            cca_model = sklearn.cross_decomposition.CCA(
+                n_components=n_components, max_iter=max_iter
+            )
 
-        try:
-            cca_model.fit(N, y_bin)
+            try:
+                cca_model.fit(N, y_bin)
 
-        except StopIteration:
-            pass
+            except StopIteration:
+                pass
 
-        N_tf, y_tf = cca_model.transform(N, y_bin)
-
-        warnings.filterwarnings("default", category=UserWarning)
+            N_tf, y_tf = cca_model.transform(N, y_bin)
 
         ind = 0
         can_cors = np.zeros(n_components, dtype=float)

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -12,8 +12,7 @@ from . import utils
 GNAME = "framework-testing"
 
 
-def summary_exception(values: np.ndarray,
-                      raise_exception: bool = False) -> int:
+def summary_exception(values: np.ndarray, raise_exception: bool = False) -> int:
     """Returns the length of ``values`` or raise a ValueError exception."""
     if raise_exception:
         raise ValueError("Summary exception raised.")
@@ -21,8 +20,7 @@ def summary_exception(values: np.ndarray,
     return len(values)
 
 
-def summary_memory_error(values: np.ndarray,
-                         raise_mem_err: bool = False) -> int:
+def summary_memory_error(values: np.ndarray, raise_mem_err: bool = False) -> int:
     """Returns the length of ``values`` or raise a MemoryError exception."""
     if raise_mem_err:
         utils.raise_memory_error()
@@ -32,6 +30,7 @@ def summary_memory_error(values: np.ndarray,
 
 class MFETestClass:
     """Some generic methods for testing the MFE Framework."""
+
     @classmethod
     def postprocess_return_none(cls, **kwargs) -> None:
         """Postprocess: return None."""
@@ -39,16 +38,15 @@ class MFETestClass:
 
     @classmethod
     def postprocess_return_new_feature(
-            cls,
-            number_of_lists: int = 3,
-            **kwargs) -> t.Tuple[t.List, t.List, t.List]:
+        cls, number_of_lists: int = 3, **kwargs
+    ) -> t.Tuple[t.List, t.List, t.List]:
         """Postprocess: return Tuple of lists."""
         return tuple(["test_value"] for _ in range(number_of_lists))
 
     @classmethod
-    def postprocess_raise_exception(cls,
-                                    raise_exception: bool = False,
-                                    **kwargs) -> None:
+    def postprocess_raise_exception(
+        cls, raise_exception: bool = False, **kwargs
+    ) -> None:
         """Posprocess: raise exception."""
         if raise_exception:
             raise ValueError("Expected exception (postprocess).")
@@ -56,9 +54,9 @@ class MFETestClass:
         return None
 
     @classmethod
-    def postprocess_memory_error(cls,
-                                 raise_mem_err: bool = False,
-                                 **kwargs) -> t.Optional[np.ndarray]:
+    def postprocess_memory_error(
+        cls, raise_mem_err: bool = False, **kwargs
+    ) -> t.Optional[np.ndarray]:
         """Posprocess: memory error."""
         if raise_mem_err:
             return utils.raise_memory_error()
@@ -83,9 +81,9 @@ class MFETestClass:
         return precomp_vals
 
     @classmethod
-    def precompute_raise_exception(cls,
-                                   raise_exception: bool = False,
-                                   **kwargs) -> t.Dict[str, t.Any]:
+    def precompute_raise_exception(
+        cls, raise_exception: bool = False, **kwargs
+    ) -> t.Dict[str, t.Any]:
         """Precompute: raise exception."""
         precomp_vals = {}
 
@@ -95,9 +93,7 @@ class MFETestClass:
         return precomp_vals
 
     @classmethod
-    def precompute_memory_error(cls,
-                                raise_mem_err: bool = False,
-                                **kwargs) -> None:
+    def precompute_memory_error(cls, raise_mem_err: bool = False, **kwargs) -> None:
         """Precompute: memory error."""
         precomp_vals = {}
 
@@ -117,8 +113,9 @@ class MFETestClass:
         return np.zeros(5)
 
     @classmethod
-    def ft_raise_exception(cls, X: np.ndarray, y: np.ndarray,
-                           raise_exception: False) -> float:
+    def ft_raise_exception(
+        cls, X: np.ndarray, y: np.ndarray, raise_exception: False
+    ) -> float:
         """Metafeature: float type."""
         if raise_exception:
             raise ValueError("Expected exception (feature).")
@@ -126,9 +123,7 @@ class MFETestClass:
         return -1.0
 
     @classmethod
-    def ft_memory_error(cls,
-                        raise_mem_err: bool = False,
-                        **kwargs) -> np.ndarray:
+    def ft_memory_error(cls, raise_mem_err: bool = False, **kwargs) -> np.ndarray:
         """Metafeature: memory error."""
         if raise_mem_err:
             return utils.raise_memory_error()
@@ -138,33 +133,36 @@ class MFETestClass:
 
 class TestArchitecture:
     """Tests for the framework architecture."""
+
     def test_summary_valid1(self):
         vals = np.arange(5)
 
-        res = _internal.summarize(features=vals,
-                                  callable_sum=summary_exception)
+        res = _internal.summarize(features=vals, callable_sum=summary_exception)
 
         assert res == len(vals)
 
     def test_summary_valid2(self):
         vals = np.arange(5)
 
-        res = _internal.summarize(features=vals,
-                                  callable_sum=summary_memory_error)
+        res = _internal.summarize(features=vals, callable_sum=summary_memory_error)
 
         assert res == len(vals)
 
     def test_summary_invalid1(self):
-        res = _internal.summarize(features=np.arange(5),
-                                  callable_sum=summary_exception,
-                                  callable_args={"raise_exception": True})
+        res = _internal.summarize(
+            features=np.arange(5),
+            callable_sum=summary_exception,
+            callable_args={"raise_exception": True},
+        )
 
         assert np.isnan(res)
 
     def test_summary_invalid2(self):
-        res = _internal.summarize(features=np.arange(5),
-                                  callable_sum=summary_memory_error,
-                                  callable_args={"raise_mem_err": True})
+        res = _internal.summarize(
+            features=np.arange(5),
+            callable_sum=summary_memory_error,
+            callable_args={"raise_mem_err": True},
+        )
 
         assert np.isnan(res)
 
@@ -172,16 +170,17 @@ class TestArchitecture:
         """Test valid postprocessing and its automatic detection."""
         results = [], [], []
 
-        _internal.post_processing(results=results,
-                                  groups=tuple(),
-                                  custom_class_=MFETestClass)
+        _internal.post_processing(
+            results=results, groups=tuple(), custom_class_=MFETestClass
+        )
 
         assert all(map(lambda l: len(l) > 0, results))
 
     def test_preprocessing_valid(self):
         """Test valid precomputation and its automatic detection."""
         precomp_args = _internal.process_precomp_groups(
-            precomp_groups=tuple(), groups=tuple(), custom_class_=MFETestClass)
+            precomp_groups=tuple(), groups=tuple(), custom_class_=MFETestClass
+        )
 
         assert len(precomp_args) > 0
 
@@ -191,25 +190,29 @@ class TestArchitecture:
             features="all",
             groups=tuple(),
             suppress_warnings=True,
-            custom_class_=MFETestClass)
+            custom_class_=MFETestClass,
+        )
 
         assert len(name) == 4 and len(mtd) == 4 and len(groups) == 1
 
     def test_get_groups(self):
         model = MFE()
         res = model.valid_groups()
-        assert (len(res) == len(_internal.VALID_GROUPS)
-                and not set(res).symmetric_difference(_internal.VALID_GROUPS))
+        assert len(res) == len(_internal.VALID_GROUPS) and not set(
+            res
+        ).symmetric_difference(_internal.VALID_GROUPS)
 
     def test_metafeature_description(self):
         desc, _ = MFE.metafeature_description(print_table=False)
         groups = [d[0] for d in desc]
         assert len(set(groups)) == len(_internal.VALID_GROUPS)
 
-        desc, _ = MFE.metafeature_description(sort_by_group=True,
-                                              sort_by_mtf=True,
-                                              print_table=False,
-                                              include_references=True)
+        desc, _ = MFE.metafeature_description(
+            sort_by_group=True,
+            sort_by_mtf=True,
+            print_table=False,
+            include_references=True,
+        )
         mtf = [d[1] for d in desc]
         assert mtf[1][0] < mtf[-1][0]
 
@@ -230,43 +233,49 @@ class TestArchitecture:
     def test_default_alias_groups(self):
         model = MFE(groups="default")
         res = model.valid_groups()
-        assert (len(res) == len(_internal.VALID_GROUPS)
-                and not set(res).symmetric_difference(_internal.VALID_GROUPS))
+        assert len(res) == len(_internal.VALID_GROUPS) and not set(
+            res
+        ).symmetric_difference(_internal.VALID_GROUPS)
 
         model = MFE(groups=["default"])
         res = model.valid_groups()
-        assert (len(res) == len(_internal.VALID_GROUPS)
-                and not set(res).symmetric_difference(_internal.VALID_GROUPS))
+        assert len(res) == len(_internal.VALID_GROUPS) and not set(
+            res
+        ).symmetric_difference(_internal.VALID_GROUPS)
 
         model = MFE(groups=["general", "default"])
         res = model.valid_groups()
-        assert (len(res) == len(_internal.VALID_GROUPS)
-                and not set(res).symmetric_difference(_internal.VALID_GROUPS))
+        assert len(res) == len(_internal.VALID_GROUPS) and not set(
+            res
+        ).symmetric_difference(_internal.VALID_GROUPS)
 
-    @pytest.mark.parametrize("groups, summary", [
-        ("statistical", "all"),
-        ("general", "all"),
-        ("landmarking", "all"),
-        ("relative", "all"),
-        ("model-based", "all"),
-        ("info-theory", "all"),
-        ("statistical", ("mean", "sd")),
-        ("general", ("mean", "sd")),
-        ("landmarking", ("mean", "sd")),
-        ("model-based", ("mean", "sd")),
-        ("general", ("mean", "histogram")),
-        ("landmarking", ("mean", "histogram")),
-        ("model-based", ("mean", "histogram")),
-        ("general", ("quantiles", "histogram")),
-        ("landmarking", ("quantiles", "histogram")),
-        ("model-based", ("quantiles", "histogram")),
-        (["general", "relative"], ("mean", "sd")),
-        (["general", "relative"], ("quantiles", "histogram")),
-        (["landmarking", "relative"], ("mean", "sd")),
-        (["landmarking", "relative"], ("quantiles", "histogram")),
-        (["statistical", "landmarking", "relative"], ("mean", "sd")),
-        ("all", "all"),
-    ])
+    @pytest.mark.parametrize(
+        "groups, summary",
+        [
+            ("statistical", "all"),
+            ("general", "all"),
+            ("landmarking", "all"),
+            ("relative", "all"),
+            ("model-based", "all"),
+            ("info-theory", "all"),
+            ("statistical", ("mean", "sd")),
+            ("general", ("mean", "sd")),
+            ("landmarking", ("mean", "sd")),
+            ("model-based", ("mean", "sd")),
+            ("general", ("mean", "histogram")),
+            ("landmarking", ("mean", "histogram")),
+            ("model-based", ("mean", "histogram")),
+            ("general", ("quantiles", "histogram")),
+            ("landmarking", ("quantiles", "histogram")),
+            ("model-based", ("quantiles", "histogram")),
+            (["general", "relative"], ("mean", "sd")),
+            (["general", "relative"], ("quantiles", "histogram")),
+            (["landmarking", "relative"], ("mean", "sd")),
+            (["landmarking", "relative"], ("quantiles", "histogram")),
+            (["statistical", "landmarking", "relative"], ("mean", "sd")),
+            ("all", "all"),
+        ],
+    )
     def test_extract_metafeature_names_supervised(self, groups, summary):
         """Test .extract_metafeature_names method."""
         X, y = utils.load_xy(0)
@@ -278,30 +287,33 @@ class TestArchitecture:
 
         assert mtf_names_1 == tuple(mtf_names_2)
 
-    @pytest.mark.parametrize("groups, summary", [
-        ("statistical", "all"),
-        ("general", "all"),
-        ("landmarking", "all"),
-        ("relative", "all"),
-        ("model-based", "all"),
-        ("info-theory", "all"),
-        ("statistical", ("mean", "sd")),
-        ("general", ("mean", "sd")),
-        ("landmarking", ("mean", "sd")),
-        ("model-based", ("mean", "sd")),
-        ("general", ("mean", "histogram")),
-        ("landmarking", ("mean", "histogram")),
-        ("model-based", ("mean", "histogram")),
-        ("general", ("quantiles", "histogram")),
-        ("landmarking", ("quantiles", "histogram")),
-        ("model-based", ("quantiles", "histogram")),
-        (["general", "relative"], ("mean", "sd")),
-        (["general", "relative"], ("quantiles", "histogram")),
-        (["landmarking", "relative"], ("mean", "sd")),
-        (["landmarking", "relative"], ("quantiles", "histogram")),
-        (["statistical", "landmarking", "relative"], ("mean", "sd")),
-        ("all", "all"),
-    ])
+    @pytest.mark.parametrize(
+        "groups, summary",
+        [
+            ("statistical", "all"),
+            ("general", "all"),
+            ("landmarking", "all"),
+            ("relative", "all"),
+            ("model-based", "all"),
+            ("info-theory", "all"),
+            ("statistical", ("mean", "sd")),
+            ("general", ("mean", "sd")),
+            ("landmarking", ("mean", "sd")),
+            ("model-based", ("mean", "sd")),
+            ("general", ("mean", "histogram")),
+            ("landmarking", ("mean", "histogram")),
+            ("model-based", ("mean", "histogram")),
+            ("general", ("quantiles", "histogram")),
+            ("landmarking", ("quantiles", "histogram")),
+            ("model-based", ("quantiles", "histogram")),
+            (["general", "relative"], ("mean", "sd")),
+            (["general", "relative"], ("quantiles", "histogram")),
+            (["landmarking", "relative"], ("mean", "sd")),
+            (["landmarking", "relative"], ("quantiles", "histogram")),
+            (["statistical", "landmarking", "relative"], ("mean", "sd")),
+            ("all", "all"),
+        ],
+    )
     def test_extract_metafeature_names_unsupervised_01(self, groups, summary):
         """Test .extract_metafeature_names method."""
         X, _ = utils.load_xy(0)
@@ -313,16 +325,19 @@ class TestArchitecture:
 
         assert mtf_names_1 == tuple(mtf_names_2)
 
-    @pytest.mark.parametrize("groups, summary", [
-        ("general", "all"),
-        ("statistical", ("mean", "sd")),
-        (["general", "relative"], ("mean", "sd")),
-        (["general", "relative"], ("quantiles", "histogram")),
-        (["landmarking", "relative"], ("mean", "sd")),
-        (["landmarking", "relative"], ("quantiles", "histogram")),
-        (["statistical", "landmarking", "relative"], ("mean", "sd")),
-        ("all", "all"),
-    ])
+    @pytest.mark.parametrize(
+        "groups, summary",
+        [
+            ("general", "all"),
+            ("statistical", ("mean", "sd")),
+            (["general", "relative"], ("mean", "sd")),
+            (["general", "relative"], ("quantiles", "histogram")),
+            (["landmarking", "relative"], ("mean", "sd")),
+            (["landmarking", "relative"], ("quantiles", "histogram")),
+            (["statistical", "landmarking", "relative"], ("mean", "sd")),
+            ("all", "all"),
+        ],
+    )
     def test_extract_metafeature_names_unsupervised_02(self, groups, summary):
         """Test .extract_metafeature_names method."""
         X, _ = utils.load_xy(0)
@@ -339,26 +354,26 @@ class TestArchitecture:
 
         assert tuple(mtf_names_1) == mtf_names_2 == mtf_names_3
 
-    @pytest.mark.parametrize("groups", [
-        "statistical",
-        "general",
-        "landmarking",
-        "relative",
-        "model-based",
-        "info-theory",
-        ("statistical", "landmarking"),
-        ("landmarking", "relative"),
-        ("general", "model-based", "statistical"),
-        ("statistical", "statistical"),
-    ])
+    @pytest.mark.parametrize(
+        "groups",
+        [
+            "statistical",
+            "general",
+            "landmarking",
+            "relative",
+            "model-based",
+            "info-theory",
+            ("statistical", "landmarking"),
+            ("landmarking", "relative"),
+            ("general", "model-based", "statistical"),
+            ("statistical", "statistical"),
+        ],
+    )
     def test_parse_valid_metafeatures(self, groups):
         """Check the length of valid metafeatures per group."""
         X, y = utils.load_xy(0)
 
-        mfe = MFE(groups="all",
-                  summary=None,
-                  lm_sample_frac=0.5,
-                  random_state=1234)
+        mfe = MFE(groups="all", summary=None, lm_sample_frac=0.5, random_state=1234)
 
         mfe.fit(X.values, y.values)
 
@@ -428,24 +443,21 @@ class TestArchitecture:
     def test_extract_with_confidence(self, confidence):
         X, y = utils.load_xy(2)
 
-        mtf_names, mtf_vals, mtf_conf_int = MFE(
-            groups="all",
-            features=["mean", "best_node", "sil"],
-            random_state=1234).fit(
-                X=X.values, y=y.values, precomp_groups=None).extract_with_confidence(
-                    sample_num=64,
-                    return_avg_val=False,
-                    confidence=confidence,
-                    verbose=0)
+        mtf_names, mtf_vals, mtf_conf_int = (
+            MFE(groups="all", features=["mean", "best_node", "sil"], random_state=1234)
+            .fit(X=X.values, y=y.values, precomp_groups=None)
+            .extract_with_confidence(sample_num=64, confidence=confidence, verbose=0)
+        )
 
-        in_range_prop = np.zeros(len(mtf_names), dtype=float)
+        in_range = np.zeros(len(mtf_names), dtype=bool)
 
         for mtf_ind, cur_mtf_vals in enumerate(mtf_vals):
             int_low, int_high = mtf_conf_int[mtf_ind, :]
-            in_range_prop[mtf_ind] = np.sum(np.logical_and(
-                int_low <= cur_mtf_vals, cur_mtf_vals <= int_high)) / len(cur_mtf_vals)
+            in_range[mtf_ind] = np.logical_and(
+                int_low <= cur_mtf_vals, cur_mtf_vals <= int_high
+            )
 
-        assert np.all(confidence - 0.05 <= in_range_prop)
+        assert np.all(in_range)
 
     def test_extract_with_confidence_invalid1(self):
         with pytest.raises(TypeError):
@@ -455,99 +467,105 @@ class TestArchitecture:
         X, y = utils.load_xy(2)
 
         with pytest.raises(ValueError):
-            MFE().fit(
-                X.values, y.values).extract_with_confidence(confidence=-0.0001)
+            MFE().fit(X.values, y.values).extract_with_confidence(confidence=-0.0001)
 
     def test_extract_with_confidence_invalid3(self):
         X, y = utils.load_xy(2)
 
         with pytest.raises(ValueError):
-            MFE().fit(
-                X.values, y.values).extract_with_confidence(confidence=1.0001)
+            MFE().fit(X.values, y.values).extract_with_confidence(confidence=1.0001)
 
-    @pytest.mark.parametrize("return_avg_val", (True, False))
-    def test_extract_with_confidence_time(self, return_avg_val):
+    def test_extract_with_confidence_time(self):
         X, y = utils.load_xy(2)
 
-        res = MFE(
-            features=["mean", "nr_inst", "unknown"],
-            measure_time="avg").fit(
-                X=X.values, y=y.values).extract_with_confidence(
-                    sample_num=3,
-                    return_avg_val=return_avg_val)
+        res = (
+            MFE(features=["mean", "nr_inst", "unknown"], measure_time="avg")
+            .fit(X=X.values, y=y.values)
+            .extract_with_confidence(sample_num=3)
+        )
 
         mtf_names, mtf_vals, mtf_time, mtf_conf_int = res
 
-        assert (len(mtf_names) == len(mtf_vals) == len(mtf_time) == len(mtf_conf_int))
+        assert len(mtf_names) == len(mtf_vals) == len(mtf_time) == len(mtf_conf_int)
 
     def test_extract_with_confidence_multiple_conf_level(self):
         X, y = utils.load_xy(2)
 
         confidence = [0.8, 0.9, 0.7]
 
-        mtf_conf_int = MFE(
-            features=["mean", "nr_inst", "unknown"]).fit(
-                X=X.values, y=y.values).extract_with_confidence(
-                    sample_num=2,
-                    confidence=confidence)[2]
+        mtf_conf_int = (
+            MFE(features=["mean", "nr_inst", "unknown"])
+            .fit(X=X.values, y=y.values)
+            .extract_with_confidence(sample_num=2, confidence=confidence)[2]
+        )
 
         assert 2 * len(confidence) == mtf_conf_int.shape[1]
 
     def test_extract_with_confidence_random_state1(self):
         X, y = utils.load_xy(2)
 
-        _, mtf_vals_1, mtf_conf_int_1 = MFE(
-            features=["mean", "sd"], random_state=16).fit(
-                X=X.values, y=y.values).extract_with_confidence(
-                    sample_num=3)
+        _, mtf_vals_1, mtf_conf_int_1 = (
+            MFE(features=["mean", "sd"], random_state=16)
+            .fit(X=X.values, y=y.values)
+            .extract_with_confidence(sample_num=3)
+        )
 
-        _, mtf_vals_2, mtf_conf_int_2 = MFE(
-            features=["mean", "sd"], random_state=16).fit(
-                X=X.values, y=y.values).extract_with_confidence(
-                    sample_num=3)
+        _, mtf_vals_2, mtf_conf_int_2 = (
+            MFE(features=["mean", "sd"], random_state=16)
+            .fit(X=X.values, y=y.values)
+            .extract_with_confidence(sample_num=3)
+        )
 
-        assert (np.allclose(mtf_vals_1, mtf_vals_2) and
-                np.allclose(mtf_conf_int_1, mtf_conf_int_2))
+        assert np.allclose(mtf_vals_1, mtf_vals_2) and np.allclose(
+            mtf_conf_int_1, mtf_conf_int_2
+        )
 
     def test_extract_with_confidence_random_state2(self):
         X, y = utils.load_xy(2)
 
-        _, mtf_vals_1, mtf_conf_int_1 = MFE(
-            features=["mean", "sd"], random_state=16).fit(
-                X=X.values, y=y.values).extract_with_confidence(
-                    sample_num=3)
+        _, mtf_vals_1, mtf_conf_int_1 = (
+            MFE(features=["mean", "sd"], random_state=16)
+            .fit(X=X.values, y=y.values)
+            .extract_with_confidence(sample_num=3)
+        )
 
-        _, mtf_vals_2, mtf_conf_int_2 = MFE(
-            features=["mean", "sd"], random_state=17).fit(
-                X=X.values, y=y.values).extract_with_confidence(
-                    sample_num=3)
+        _, mtf_vals_2, mtf_conf_int_2 = (
+            MFE(features=["mean", "sd"], random_state=17)
+            .fit(X=X.values, y=y.values)
+            .extract_with_confidence(sample_num=3)
+        )
 
-        assert (np.any(~np.isclose(mtf_vals_1, mtf_vals_2)) and
-                np.any(~np.isclose(mtf_conf_int_1, mtf_conf_int_2)))
+        assert np.allclose(mtf_vals_1, mtf_vals_2) and np.any(
+            ~np.isclose(mtf_conf_int_1, mtf_conf_int_2)
+        )
 
     def test_extract_with_confidence_random_state3(self):
         X, y = utils.load_xy(2)
 
         np.random.seed(1234)
-        _, mtf_vals_1, mtf_conf_int_1 = MFE(
-            features=["mean", "sd"]).fit(
-                X=X.values, y=y.values).extract_with_confidence(
-                    sample_num=3)
+        _, mtf_vals_1, mtf_conf_int_1 = (
+            MFE(features=["mean", "sd"])
+            .fit(X=X.values, y=y.values)
+            .extract_with_confidence(sample_num=3)
+        )
 
         np.random.seed(1234)
-        _, mtf_vals_2, mtf_conf_int_2 = MFE(
-            features=["mean", "sd"]).fit(
-                X=X.values, y=y.values).extract_with_confidence(
-                    sample_num=3)
+        _, mtf_vals_2, mtf_conf_int_2 = (
+            MFE(features=["mean", "sd"])
+            .fit(X=X.values, y=y.values)
+            .extract_with_confidence(sample_num=3)
+        )
 
-        assert (np.any(~np.isclose(mtf_vals_1, mtf_vals_2)) and
-                np.any(~np.isclose(mtf_conf_int_1, mtf_conf_int_2)))
+        assert np.allclose(mtf_vals_1, mtf_vals_2) and np.any(
+            ~np.isclose(mtf_conf_int_1, mtf_conf_int_2)
+        )
 
     def test_extract_from_model(self):
         X, y = utils.load_xy(2)
 
         model = sklearn.tree.DecisionTreeClassifier(random_state=1234).fit(
-            X.values, y.values)
+            X.values, y.values
+        )
 
         mtf_name, mtf_vals = MFE(random_state=1234).extract_from_model(model)
 
@@ -555,8 +573,7 @@ class TestArchitecture:
         extractor.fit(X=X.values, y=y.values, transform_num=False)
         mtf_name2, mtf_vals2 = extractor.extract()
 
-        assert (np.all(mtf_name == mtf_name2)
-                and np.allclose(mtf_vals, mtf_vals2))
+        assert np.all(mtf_name == mtf_name2) and np.allclose(mtf_vals, mtf_vals2)
 
     def test_extract_from_model_invalid1(self):
         X, y = utils.load_xy(2)
@@ -570,7 +587,8 @@ class TestArchitecture:
         X, y = utils.load_xy(2)
 
         model = sklearn.tree.DecisionTreeClassifier(random_state=1234).fit(
-            X.values, y.values)
+            X.values, y.values
+        )
 
         with pytest.raises(KeyError):
             MFE().extract_from_model(model, arguments_fit={"dt_model": model})
@@ -595,81 +613,101 @@ class TestArchitectureWarnings:
         """Test exception handling of feature extraction."""
         name, mtd, groups = map(
             np.asarray,
-            _internal.process_features(features="raise_exception",
-                                       groups=tuple(),
-                                       suppress_warnings=True,
-                                       custom_class_=MFETestClass))
+            _internal.process_features(
+                features="raise_exception",
+                groups=tuple(),
+                suppress_warnings=True,
+                custom_class_=MFETestClass,
+            ),
+        )
 
         with pytest.warns(RuntimeWarning):
-            _internal.get_feat_value(mtd_name=name[0],
-                                     mtd_args={
-                                         "X": np.array([]),
-                                         "y": np.ndarray([]),
-                                         "raise_exception": True
-                                     },
-                                     mtd_callable=mtd[0][1],
-                                     suppress_warnings=False)
+            _internal.get_feat_value(
+                mtd_name=name[0],
+                mtd_args={
+                    "X": np.array([]),
+                    "y": np.ndarray([]),
+                    "raise_exception": True,
+                },
+                mtd_callable=mtd[0][1],
+                suppress_warnings=False,
+            )
 
     def test_feature_warning2(self):
         """Test memory error handling of feature extraction."""
         name, mtd, groups = map(
             np.asarray,
-            _internal.process_features(features="memory_error",
-                                       groups=tuple(),
-                                       suppress_warnings=True,
-                                       custom_class_=MFETestClass))
+            _internal.process_features(
+                features="memory_error",
+                groups=tuple(),
+                suppress_warnings=True,
+                custom_class_=MFETestClass,
+            ),
+        )
 
         with pytest.warns(RuntimeWarning):
-            _internal.get_feat_value(mtd_name=name[0],
-                                     mtd_args={
-                                         "X": np.array([]),
-                                         "y": np.ndarray([]),
-                                         "raise_mem_err": True
-                                     },
-                                     mtd_callable=mtd[0][1],
-                                     suppress_warnings=False)
+            _internal.get_feat_value(
+                mtd_name=name[0],
+                mtd_args={
+                    "X": np.array([]),
+                    "y": np.ndarray([]),
+                    "raise_mem_err": True,
+                },
+                mtd_callable=mtd[0][1],
+                suppress_warnings=False,
+            )
 
     def test_mem_err_precompute(self):
         with pytest.warns(UserWarning):
-            _internal.process_precomp_groups(precomp_groups=tuple(),
-                                             groups=tuple(),
-                                             custom_class_=MFETestClass,
-                                             raise_mem_err=True)
+            _internal.process_precomp_groups(
+                precomp_groups=tuple(),
+                groups=tuple(),
+                custom_class_=MFETestClass,
+                raise_mem_err=True,
+            )
 
     def test_mem_err_postprocess(self):
         """Test memory error in postprocessing methods."""
         results = [], [], []
 
         with pytest.warns(UserWarning):
-            _internal.post_processing(results=results,
-                                      groups=tuple(),
-                                      custom_class_=MFETestClass,
-                                      raise_mem_err=True)
+            _internal.post_processing(
+                results=results,
+                groups=tuple(),
+                custom_class_=MFETestClass,
+                raise_mem_err=True,
+            )
 
     def test_postprocessing_invalid1(self):
         """Test exception handling in invalid postprocessing."""
         results = [], [], []
 
         with pytest.warns(UserWarning):
-            _internal.post_processing(results=results,
-                                      groups=tuple(),
-                                      custom_class_=MFETestClass,
-                                      raise_exception=True)
+            _internal.post_processing(
+                results=results,
+                groups=tuple(),
+                custom_class_=MFETestClass,
+                raise_exception=True,
+            )
 
     def test_postprocessing_invalid2(self):
         """Test incorrect return value in postprocessing methods."""
         results = [], [], []
 
         with pytest.warns(UserWarning):
-            _internal.post_processing(results=results,
-                                      groups=tuple(),
-                                      custom_class_=MFETestClass,
-                                      number_of_lists=2)
+            _internal.post_processing(
+                results=results,
+                groups=tuple(),
+                custom_class_=MFETestClass,
+                number_of_lists=2,
+            )
 
     def test_preprocessing_invalid(self):
         """Test exception handling of precomputation."""
         with pytest.warns(UserWarning):
-            _internal.process_precomp_groups(precomp_groups=tuple(),
-                                             groups=tuple(),
-                                             custom_class_=MFETestClass,
-                                             raise_exception=True)
+            _internal.process_precomp_groups(
+                precomp_groups=tuple(),
+                groups=tuple(),
+                custom_class_=MFETestClass,
+                raise_exception=True,
+            )

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -460,9 +460,15 @@ class TestArchitecture:
         X, y = utils.load_xy(2)
 
         mtf_names, mtf_vals, mtf_conf_int = (
-            MFE(groups="all", features=["mean", "best_node", "sil"], random_state=1234)
+            MFE(
+                groups="all",
+                features=["mean", "best_node", "sil"],
+                random_state=1234,
+            )
             .fit(X=X.values, y=y.values, precomp_groups=None)
-            .extract_with_confidence(sample_num=64, confidence=confidence, verbose=0)
+            .extract_with_confidence(
+                sample_num=64, confidence=confidence, verbose=0
+            )
         )
 
         in_range = np.zeros(len(mtf_names), dtype=bool)
@@ -483,13 +489,17 @@ class TestArchitecture:
         X, y = utils.load_xy(2)
 
         with pytest.raises(ValueError):
-            MFE().fit(X.values, y.values).extract_with_confidence(confidence=-0.0001)
+            MFE().fit(X.values, y.values).extract_with_confidence(
+                confidence=-0.0001
+            )
 
     def test_extract_with_confidence_invalid3(self):
         X, y = utils.load_xy(2)
 
         with pytest.raises(ValueError):
-            MFE().fit(X.values, y.values).extract_with_confidence(confidence=1.0001)
+            MFE().fit(X.values, y.values).extract_with_confidence(
+                confidence=1.0001
+            )
 
     def test_extract_with_confidence_time(self):
         X, y = utils.load_xy(2)
@@ -502,7 +512,12 @@ class TestArchitecture:
 
         mtf_names, mtf_vals, mtf_time, mtf_conf_int = res
 
-        assert len(mtf_names) == len(mtf_vals) == len(mtf_time) == len(mtf_conf_int)
+        assert (
+            len(mtf_names)
+            == len(mtf_vals)
+            == len(mtf_time)
+            == len(mtf_conf_int)
+        )
 
     def test_extract_with_confidence_multiple_conf_level(self):
         X, y = utils.load_xy(2)
@@ -589,7 +604,9 @@ class TestArchitecture:
         extractor.fit(X=X.values, y=y.values, transform_num=False)
         mtf_name2, mtf_vals2 = extractor.extract()
 
-        assert np.all(mtf_name == mtf_name2) and np.allclose(mtf_vals, mtf_vals2)
+        assert np.all(mtf_name == mtf_name2) and np.allclose(
+            mtf_vals, mtf_vals2
+        )
 
     def test_extract_from_model_invalid1(self):
         X, y = utils.load_xy(2)

--- a/tests/test_errors_warnings.py
+++ b/tests/test_errors_warnings.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from pymfe.mfe import MFE
 from pymfe import _internal
+from pymfe import _bootstrap
 from tests.utils import load_xy
 
 GNAME = "errors-warnings"
@@ -331,5 +332,11 @@ class TestErrorsWarnings:
 
     def test_extract_with_confidence_without_data(self):
         mfe = MFE()
+        with pytest.raises(TypeError):
+            mfe.extract_with_confidence()
+
+    def test_bootstrap_extractor_extract_with_confidence_without_data(self):
+        mfe = MFE()
+        bootstrap_extractor = _bootstrap.BootstrapExtractor(extractor=mfe)
         with pytest.raises(TypeError):
             mfe.extract_with_confidence()

--- a/tests/test_errors_warnings.py
+++ b/tests/test_errors_warnings.py
@@ -292,3 +292,8 @@ class TestErrorsWarnings:
         with pytest.raises(ValueError):
             mfe = MFE()
             mfe.fit(X.values, y.values, transform_cat="invalid")
+
+    def test_extract_with_confidence_without_data(self):
+        mfe = MFE()
+        with pytest.raises(TypeError):
+            mfe.extract_with_confidence()


### PR DESCRIPTION
## Context
While using `MFE.extract_with_confidence()` method, the currently used bootstrap method known as 'Bootstrap percentile method', although correct, may not be very reliable. From a MIT notes about bootstrap confidence intervals (check references for the URL):

> The bootstrap percentile method is appealing due to its simplicity. However it depends on the bootstrap distribution based on a particular sample being a good approximation to the true distribution of X (the population). Rice says of the percentile method, “Although this direct equation of quantiles of the bootstrap sampling distribution with confidence limits may seem initially appealing, it’s rationale is some what obscure". (source: J. Rice, Mathematical Statistics and Data Analysis, 2nd ed., page 272.)

### The current pymfe confidence interval method
In summary, the current confidence interval algorithm works as follows:
```
Description of 'Bootstrap percentile method'.
- Let (X, y) be the fitted data in a MFE model.
- Let M be an initially empty list.
- Let 'alpha' be the desired Type I Error rate, 0 < alpha < 1.

1. Repeat n times:
    1.1. Resample (X_i, y_i) from (X, y) using bootstrap;
    1.2. Compute meta-features m_i from (X_i, y_i) normally and store its results in M;
2. Compute (alpha/2) and (1 - alpha/2) quantiles, Lower and Upper respectively, from M;
3. (1 - alpha) confidence interval is given by [Lower, Upper]
```

### The confidence interval method proposed in this PR
With just a handful code changes, we can do better.
```
Description of 'Empirical bootstrap method'.
- Let (X, y) be the fitted data in a MFE model.
- Let D be an initially empty list.
- Let 'alpha' be the desired Type I Error rate, 0 < alpha < 1.

1. Compute the meta-features m from (X, y) normally.
1. Repeat n times:
    1.1. Resample (X_i, y_i) from (X, y) using bootstrap;
    1.2. Compute meta-features m_i from (X_i, y_i) normally;
    1.3. Compute d_i = (m_i - m) and store in D;
2. Compute (1 - alpha/2) and (alpha/2) quantiles, 'LowerDiff' and 'UpperDiff' respectively, from D;
3. (1 - alpha) confidence interval is given by [m - LowerDiff, m - UpperDiff].
```

### Additional information
[This notes about bootstrap confidence intervals](https://ocw.mit.edu/courses/mathematics/18-05-introduction-to-probability-and-statistics-spring-2014/readings/MIT18_05S14_Reading24.pdf) (URL in references section) provide a better description between the distinction about the Bootstrap percentile method (the method currently used in pymfe) and the Empirical Bootstrap (the method used in this PR).

- The proposed algorithm in this PR, the Empirical Bootstrap method, is explained detailed in pages 4 to 8.
- The current algorithm, the Bootstrap percentile method, is explained briefly in page 10.

## PR Changes
### Major changes
- Created a new module _bootstrap.py with a new class `BootstrapExtractor`;
- Moved all code related to bootstrapping to _bootstrap.py, so the mfe.py module is now simpler;
- Now using Empirical Bootstrap method, instead of the Bootstrap percentile method;
- Removed `return_avg_val` from the MFE.extract_with_confidence() method, since it no longer makes sense with the new bootstrap method;

### Minor related changes
- Improved verbosity mode of `extract_with_confidence` method;
- Updated MFE.extract_with_confidence() documentation;
- Updated tests to reflect the new bootstrapping strategy;

### Minor unrelated changes
- Updated exception message when trying to extract a meta-feature not in any specified groups in a MFE model instantiation, to provide to the user a better understanding of how to proceed (instead of just mentioning methods like 'valid_metafeatures()', say 'MFE.valid_metafeatures()' to make it clear where the method is from).
- Preventing spurious warnings in CCA (statistical module) using a better method; previously updating warnings configuration globally, now using a context manager.
- Catching IndexError on histogram summary function to prevent errors from very weird, edge cases (found a very particular input where this error occurs while testing ts-pymfe, where values=[1.12886304e+16])

## References
- MIT Notes about bootstrap confidence intervals: https://ocw.mit.edu/courses/mathematics/18-05-introduction-to-probability-and-statistics-spring-2014/readings/MIT18_05S14_Reading24.pdf
- John Rice, Mathematical Statistics and Data Analysis, 2nd edition, p.272.