### PR TITLE
Fix README math rendering in dark themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,16 @@ documentation.
 
 In the Meta-learning (MtL) literature, meta-features are measures used to
 characterize data sets and/or their relations with algorithm bias.
-According to Brazdil et al. (2008), "Meta-learning is the study of principled
-methods that exploit meta-knowledge to obtain efficient models and solutions by
-adapting the machine learning and data mining process".
+
+> "Meta-learning is the study of principled methods that exploit meta-knowledge to obtain efficient models and solutions by adapting the machine learning and data mining process." - ([Brazdil et al. (2008)](https://www.springer.com/gp/book/9783540732624)).
 
 Meta-features are used in MtL and AutoML tasks in general, to
 represent/understand a dataset,  to understanding a learning bias, to create
 machine learning (or data mining) recommendations systems, and to create
 surrogates models, to name a few.
 
-Pinto et al. (2016) and Rivolli et al. (2018) defined a meta-feature as
+[Pinto et al. (2016)](https://link.springer.com/chapter/10.1007/978-3-319-31753-3_18) and
+[Rivolli et al. (2018)](https://arxiv.org/abs/1808.10406v2) defined a meta-feature as
 follows. Let $D \in \mathcal{D}$ be a dataset, $m\colon \mathcal{D} \to \mathbb{R}^{k'}$
 be a characterization measure, and $\sigma\colon \mathbb{R}^{k'} \to \mathbb{R}^{k}$
 be a summarization function. Both $m$ and $\sigma$ have also hyperparameters associated,

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ machine learning (or data mining) recommendations systems, and to create
 surrogates models, to name a few.
 
 Pinto et al. (2016) and Rivolli et al. (2018) defined a meta-feature as
-follows. Let <img src="https://render.githubusercontent.com/render/math?math=D \in \mathcal{D}">
+follows. Let $D \in \mathcal{D}$ <img src="https://render.githubusercontent.com/render/math?math=D \in \mathcal{D}">
 be a dataset, <img src="https://render.githubusercontent.com/render/math?math=m\colon \mathcal{D} \to \mathbb{R}^{k'}">
 be a characterization measure, and
 <img src="https://render.githubusercontent.com/render/math?math=\sigma\colon \mathbb{R}^{k'} \to \mathbb{R}^{k}">

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $h_m$ and $h_\sigma$ respectively. Thus, a meta-feature $f\colon \mathcal{D} \to
 for a given dataset $D$ is
 
 $$
-    $f\big(D\big) = \sigma\big(m(D,h_m), h_\sigma\big)$.
+    f\big(D\big) = \sigma\big(m(D,h_m), h_\sigma\big).
 $$
 
 The measure $m$ can extract more than one value from each data set, i.e.,
@@ -87,22 +87,22 @@ The main `pymfe` requirement is:
 
 The installation process is similar to other packages available on pip:
 
-```python
+```bash
 pip install -U pymfe
 ```
 
 It is possible to install the development version using:
 
-```python
+```bash
 pip install -U git+https://github.com/ealcobaca/pymfe
 ```
 
 or
 
-```
+```bash
 git clone https://github.com/ealcobaca/pymfe.git
 cd pymfe
-python3 setup.py install
+python setup.py install
 ```
 
 ## Example of use

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ documentation.
 In the Meta-learning (MtL) literature, meta-features are measures used to
 characterize data sets and/or their relations with algorithm bias.
 
-> "Meta-learning is the study of principled methods that exploit meta-knowledge to obtain efficient models and solutions by adapting the machine learning and data mining process." - ([Brazdil et al. (2008)](https://www.springer.com/gp/book/9783540732624)).
+> "Meta-learning is the study of principled methods that exploit meta-knowledge to obtain efficient models and solutions by adapting the machine learning and data mining process." - ([Brazdil et al. (2008)](https://www.springer.com/gp/book/9783540732624))
 
 Meta-features are used in MtL and AutoML tasks in general, to
 represent/understand a dataset,  to understanding a learning bias, to create

--- a/README.md
+++ b/README.md
@@ -35,53 +35,39 @@ machine learning (or data mining) recommendations systems, and to create
 surrogates models, to name a few.
 
 Pinto et al. (2016) and Rivolli et al. (2018) defined a meta-feature as
-follows. Let $D \in \mathcal{D}$ <img src="https://render.githubusercontent.com/render/math?math=D \in \mathcal{D}">
-be a dataset, <img src="https://render.githubusercontent.com/render/math?math=m\colon \mathcal{D} \to \mathbb{R}^{k'}">
-be a characterization measure, and
-<img src="https://render.githubusercontent.com/render/math?math=\sigma\colon \mathbb{R}^{k'} \to \mathbb{R}^{k}">
-be a summarization function. Both
-<img src="https://render.githubusercontent.com/render/math?math=m"> and 
-<img src="https://render.githubusercontent.com/render/math?math=\sigma">
-have also hyperparameters associated,
-<img src="https://render.githubusercontent.com/render/math?math=h_m"> and
-<img src="https://render.githubusercontent.com/render/math?math=h_\sigma"> respectively.
-Thus, a meta-feature
-<img src="https://render.githubusercontent.com/render/math?math=f\colon \mathcal{D} \to \mathbb{R}^{k}">
-for a given dataset
-<img src="https://render.githubusercontent.com/render/math?math=D"> is:
+follows. Let $D \in \mathcal{D}$ be a dataset, $m\colon \mathcal{D} \to \mathbb{R}^{k'}$
+be a characterization measure, and $\sigma\colon \mathbb{R}^{k'} \to \mathbb{R}^{k}$
+be a summarization function. Both $m$ and $\sigma$ have also hyperparameters associated,
+$h_m$ and $h_\sigma$ respectively. Thus, a meta-feature $f\colon \mathcal{D} \to \mathbb{R}^{k}$
+for a given dataset $D$ is
 
-<p align="center">
-    <img src="https://render.githubusercontent.com/render/math?math=f\big(D\big) = \sigma\big(m(D,h_m), h_\sigma\big)">.
-</p>
+$$
+    $f\big(D\big) = \sigma\big(m(D,h_m), h_\sigma\big)$.
+$$
 
-The measure <img src="https://render.githubusercontent.com/render/math?math=m">
-can extract more than one value from each data set, i.e.,
-<img src="https://render.githubusercontent.com/render/math?math=k'">
-can vary according to <img src="https://render.githubusercontent.com/render/math?math=D">,
-which can be mapped to a vector of fixed length
-<img src="https://render.githubusercontent.com/render/math?math=k">
-using a summarization function
-<img src="https://render.githubusercontent.com/render/math?math=\sigma">.
+The measure $m$ can extract more than one value from each data set, i.e.,
+$k'$ can vary according to $D$, which can be mapped to a vector of fixed length
+$k$ using a summarization function $\sigma$.
 
 In this package, We provided the following meta-features groups:
 - **General**: General information related to the dataset, also known as simple
-  measures, such as the number of instances, attributes and classes.
+  measures, such as the number of instances, attributes and classes;
 - **Statistical**: Standard statistical measures to describe the numerical
-  properties of data distribution.
+  properties of data distribution;
 - **Information-theoretic**: Particularly appropriate to describe discrete
-  (categorical) attributes and their relationship with the classes.
+  (categorical) attributes and their relationship with the classes;
 - **Model-based**: Measures designed to extract characteristics from simple
-  machine learning models.
+  machine learning models;
 - **Landmarking**: Performance of simple and efficient learning algorithms.
-- **Relative Landmarking**: Relative performance of simple and efficient
-  learning algorithms.
-- **Subsampling Landmarking**: Performance of simple and efficient learning
-  algorithms from a subsample of the dataset.
+  - **Relative Landmarking**: Relative performance of simple and efficient
+    learning algorithms;
+  - **Subsampling Landmarking**: Performance of simple and efficient learning
+    algorithms from a subsample of the dataset;
 - **Clustering**: Clustering measures extract information about dataset based
-  on external validation indexes.
+  on external validation indexes;
 - **Concept**: Estimate the variability of class labels among examples and the
-  examples density.
-- **Itemset**: Compute the correlation between binary attributes.
+  examples density;
+- **Itemset**: Compute the correlation between binary attributes; and
 - **Complexity**: Estimate the difficulty in separating the data points into
   their expected classes.
 


### PR DESCRIPTION
Currently the rendered math in README is not visible in Github dark themes. I updated the latex formulas in README to leverage the natively available Github latex renderer, which automatically applies an appropriate font color onto the rendered latex formulas.

I also linked references in the introduction to their respective materials. 